### PR TITLE
`configure` method replaced to `open` to can override

### DIFF
--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -73,7 +73,7 @@ open class SwipeTableViewCell: UITableViewCell {
         tableView?.panGestureRecognizer.removeTarget(self, action: nil)
     }
     
-    func configure() {
+    open func configure() {
         clipsToBounds = false
         
         addGestureRecognizer(tapGestureRecognizer)


### PR DESCRIPTION
When use a viewController with tabs, for example, need the gesture to switch between tabs, overriding the method configure, can intercept and personalize as I need.