### PR TITLE
% Added protection against superview being nil and crashing

### DIFF
--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -334,7 +334,8 @@ open class SwipeTableViewCell: UITableViewCell {
     // `SwipeTableCell`.
     /// :nodoc:
     override open func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        let point = convert(point, to: superview!)
+        guard let superview = superview else {return false}
+        let point = convert(point, to: superview)
 
         if !UIAccessibilityIsVoiceOverRunning() {
             for cell in tableView?.swipeCells ?? [] {

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -334,7 +334,8 @@ open class SwipeTableViewCell: UITableViewCell {
     // `SwipeTableCell`.
     /// :nodoc:
     override open func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        guard let superview = superview else {return false}
+        guard let superview = superview else { return false }
+     
         let point = convert(point, to: superview)
 
         if !UIAccessibilityIsVoiceOverRunning() {


### PR DESCRIPTION
I've seen a few crashes that look like:

`Thread 0 Crashed:
0   SwipeCellKit                         0x0000000100b32264 function signature specialization <Arg[1] = Dead> of SwipeCellKit.SwipeTableViewCell.point (inside : __C.CGPoint, with : __ObjC.UIEvent?) -> Swift.Bool (SwipeTableViewCell.swift:337)
1   SwipeCellKit                         0x0000000100b2efe4 @objc SwipeCellKit.SwipeTableViewCell.point (inside : __C.CGPoint, with : __ObjC.UIEvent?) -> Swift.Bool (SwipeTableViewCell.swift:0)
2   UIKit                                0x00000001955d3394 -[UIView(Geometry) hitTest:withEvent:] + 272
3   UIKit                                0x0000000195770778 -[UITableViewCell hitTest:withEvent:] + 108`

Which points to "superview" being "dead". I have no idea how superview would be non-existent, but it is a good idea to avoid forced unwrapping, in my opinion.

This change guards against superview being nil.