### PR TITLE
Includes an option to customize the button bottom spacing.

### DIFF
--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -9,6 +9,7 @@ import UIKit
 
 class SwipeActionButton: UIButton {
     var spacing: CGFloat = 8
+    var bottomSpacing: CGFloat = 0
     var shouldHighlight = true
     var highlightedBackgroundColor: UIColor?
 
@@ -72,13 +73,13 @@ class SwipeActionButton: UIButton {
     
     override func titleRect(forContentRect contentRect: CGRect) -> CGRect {
         var rect = contentRect.center(size: titleBoundingRect(with: contentRect.size).size)
-        rect.origin.y = alignmentRect.minY + maximumImageHeight + currentSpacing
+        rect.origin.y = alignmentRect.minY + maximumImageHeight + currentSpacing - bottomSpacing
         return rect.integral
     }
     
     override func imageRect(forContentRect contentRect: CGRect) -> CGRect {
         var rect = contentRect.center(size: currentImage?.size ?? .zero)
-        rect.origin.y = alignmentRect.minY + (maximumImageHeight - rect.height) / 2
+        rect.origin.y = alignmentRect.minY + (maximumImageHeight - rect.height) / 2 - bottomSpacing
         return rect
     }
 }

--- a/Source/SwipeActionsView.swift
+++ b/Source/SwipeActionsView.swift
@@ -109,6 +109,7 @@ class SwipeActionsView: UIView {
             actionButton.addTarget(self, action: #selector(actionTapped(button:)), for: .touchUpInside)
             actionButton.autoresizingMask = [.flexibleHeight, orientation == .right ? .flexibleRightMargin : .flexibleLeftMargin]
             actionButton.spacing = options.buttonSpacing ?? 8
+            actionButton.bottomSpacing = options.buttonBottomSpacing ?? 0
             actionButton.contentEdgeInsets = buttonEdgeInsets(fromOptions: options)
             return actionButton
         })

--- a/Source/SwipeTableOptions.swift
+++ b/Source/SwipeTableOptions.swift
@@ -42,6 +42,9 @@ public struct SwipeTableOptions {
     /// The amount of space, in points, between the button image and the button title.
     public var buttonSpacing: CGFloat?
     
+    /// The amount of space, in points, between the button bottom and its superview.
+    public var buttonBottomSpacing: CGFloat?
+    
     /// Constructs a new `SwipeTableOptions` instance with default options.
     public init() {}
 }


### PR DESCRIPTION
With this option it is possible to add a bottom inset to the button. It may be useful in cases which the cell contentView has a clear background and is larger than the actual view visible to the user.