### PR TITLE
Add support for UICollectionView with SwipeCollectionViewCell

### DIFF
--- a/Example/MailExample.xcodeproj/project.pbxproj
+++ b/Example/MailExample.xcodeproj/project.pbxproj
@@ -8,13 +8,15 @@
 
 /* Begin PBXBuildFile section */
 		3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B041E44AC2600E22A38 /* AppDelegate.swift */; };
-		3F234B0B1E44AC2600E22A38 /* MailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B051E44AC2600E22A38 /* MailViewController.swift */; };
+		3F234B0B1E44AC2600E22A38 /* MailTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B051E44AC2600E22A38 /* MailTableViewController.swift */; };
 		3F234B0C1E44AC2600E22A38 /* Data.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F234B061E44AC2600E22A38 /* Data.swift */; };
 		3F234B0D1E44AC2600E22A38 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F234B071E44AC2600E22A38 /* Main.storyboard */; };
 		3F234B0E1E44AC2600E22A38 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 3F234B081E44AC2600E22A38 /* LaunchScreen.storyboard */; };
 		3F234B0F1E44AC2600E22A38 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F234B091E44AC2600E22A38 /* Assets.xcassets */; };
 		3F234B171E44B29B00E22A38 /* SwipeCellKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F234B031E44AB7A00E22A38 /* SwipeCellKit.framework */; };
 		3F234B181E44B29B00E22A38 /* SwipeCellKit.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F234B031E44AB7A00E22A38 /* SwipeCellKit.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		B93ECA9D1EDEF1EA00AE05AD /* MailCollectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */; };
+		B93ECA9F1EDEF56300AE05AD /* Shared.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA9E1EDEF56300AE05AD /* Shared.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -53,11 +55,13 @@
 		3F234AF21E44AA5E00E22A38 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3F234AFE1E44AB7A00E22A38 /* SwipeCellKit.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = SwipeCellKit.xcodeproj; path = ../SwipeCellKit.xcodeproj; sourceTree = "<group>"; };
 		3F234B041E44AC2600E22A38 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
-		3F234B051E44AC2600E22A38 /* MailViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MailViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
+		3F234B051E44AC2600E22A38 /* MailTableViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; lineEnding = 0; path = MailTableViewController.swift; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.swift; };
 		3F234B061E44AC2600E22A38 /* Data.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Data.swift; sourceTree = "<group>"; };
 		3F234B071E44AC2600E22A38 /* Main.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = Main.storyboard; sourceTree = "<group>"; };
 		3F234B081E44AC2600E22A38 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		3F234B091E44AC2600E22A38 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MailCollectionViewController.swift; sourceTree = "<group>"; };
+		B93ECA9E1EDEF56300AE05AD /* Shared.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Shared.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -93,9 +97,11 @@
 			isa = PBXGroup;
 			children = (
 				3F234B041E44AC2600E22A38 /* AppDelegate.swift */,
-				3F234B051E44AC2600E22A38 /* MailViewController.swift */,
+				3F234B051E44AC2600E22A38 /* MailTableViewController.swift */,
+				B93ECA9C1EDEF1EA00AE05AD /* MailCollectionViewController.swift */,
 				3F234B061E44AC2600E22A38 /* Data.swift */,
 				3F234B101E44AC3400E22A38 /* Supporting Files */,
+				B93ECA9E1EDEF56300AE05AD /* Shared.swift */,
 			);
 			name = Source;
 			path = MailExample;
@@ -210,9 +216,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B93ECA9F1EDEF56300AE05AD /* Shared.swift in Sources */,
 				3F234B0A1E44AC2600E22A38 /* AppDelegate.swift in Sources */,
 				3F234B0C1E44AC2600E22A38 /* Data.swift in Sources */,
-				3F234B0B1E44AC2600E22A38 /* MailViewController.swift in Sources */,
+				3F234B0B1E44AC2600E22A38 /* MailTableViewController.swift in Sources */,
+				B93ECA9D1EDEF1EA00AE05AD /* MailCollectionViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/MailExample/MailCollectionViewController.swift
+++ b/Example/MailExample/MailCollectionViewController.swift
@@ -1,0 +1,263 @@
+//
+//  MailCollectionViewController.swift
+//
+//  Created by Jeremy Koch
+//  Copyright © 2017 Jeremy Koch. All rights reserved.
+//
+
+import UIKit
+import SwipeCellKit
+
+class MailCollectionViewController: UICollectionViewController, UICollectionViewDelegateFlowLayout {
+    var emails: [Email] = []
+    
+    var defaultOptions = SwipeOptions()
+    var isSwipeRightEnabled = true
+    var buttonDisplayMode: ButtonDisplayMode = .titleAndImage
+    var buttonStyle: ButtonStyle = .backgroundColor
+    
+    // MARK: - Lifecycle
+    
+    override func viewDidLoad() {
+        collectionView?.allowsSelection = true
+        collectionView?.allowsMultipleSelection = true
+        
+        view.layoutMargins.left = 32
+        
+        if let collectionView = collectionView {
+            let flowLayout = collectionView.collectionViewLayout as! UICollectionViewFlowLayout
+            flowLayout.minimumLineSpacing = 0
+            flowLayout.minimumInteritemSpacing = 0
+            flowLayout.itemSize = CGSize(width: collectionView.frame.width / 2.0, height: 110)
+        }
+        
+        navigationItem.rightBarButtonItem = editButtonItem
+        
+        resetData()
+    }
+    
+    override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
+        super.viewWillTransition(to: size, with: coordinator)
+        
+        coordinator.animate(alongsideTransition: { (ctx) in
+            if let collectionView = self.collectionView {
+                collectionView.collectionViewLayout.invalidateLayout()
+                collectionView.performBatchUpdates({
+                    let flowLayout = collectionView.collectionViewLayout as! UICollectionViewFlowLayout
+                    flowLayout.itemSize = CGSize(width: collectionView.frame.width / 2.0, height: 110)
+                    collectionView.setCollectionViewLayout(flowLayout, animated: true)
+                }, completion: nil)
+            }
+        }, completion: nil)
+    }
+    
+    // MARK: - Collection view data source
+    override func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return emails.count
+    }
+    
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "MailCell", for: indexPath) as! MailCollectionViewCell
+        
+        cell.delegate = self
+        cell.selectedBackgroundView = createSelectedBackgroundView()
+        
+        let email = emails[indexPath.row]
+        cell.fromLabel.text = email.from
+        cell.dateLabel.text = email.relativeDateString
+        cell.subjectLabel.text = email.subject
+        cell.bodyLabel.text = email.body
+        cell.unread = email.unread
+        
+        return cell
+    }
+    
+    // MARK: - Actions
+    
+    @IBAction func moreTapped(_ sender: Any) {
+        let controller = UIAlertController(title: "Swipe Transition Style", message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: "Border", style: .default, handler: { _ in self.defaultOptions.transitionStyle = .border }))
+        controller.addAction(UIAlertAction(title: "Drag", style: .default, handler: { _ in self.defaultOptions.transitionStyle = .drag }))
+        controller.addAction(UIAlertAction(title: "Reveal", style: .default, handler: { _ in self.defaultOptions.transitionStyle = .reveal }))
+        controller.addAction(UIAlertAction(title: "\(isSwipeRightEnabled ? "Disable" : "Enable") Swipe Right", style: .default, handler: { _ in self.isSwipeRightEnabled = !self.isSwipeRightEnabled }))
+        controller.addAction(UIAlertAction(title: "Button Display Mode", style: .default, handler: { _ in self.buttonDisplayModeTapped() }))
+        controller.addAction(UIAlertAction(title: "Button Style", style: .default, handler: { _ in self.buttonStyleTapped() }))
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        controller.addAction(UIAlertAction(title: "Reset", style: .destructive, handler: { _ in self.resetData() }))
+        present(controller, animated: true, completion: nil)
+    }
+    
+    func buttonDisplayModeTapped() {
+        let controller = UIAlertController(title: "Button Display Mode", message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: "Image + Title", style: .default, handler: { _ in self.buttonDisplayMode = .titleAndImage }))
+        controller.addAction(UIAlertAction(title: "Image Only", style: .default, handler: { _ in self.buttonDisplayMode = .imageOnly }))
+        controller.addAction(UIAlertAction(title: "Title Only", style: .default, handler: { _ in self.buttonDisplayMode = .titleOnly }))
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        present(controller, animated: true, completion: nil)
+    }
+    
+    func buttonStyleTapped() {
+        let controller = UIAlertController(title: "Button Style", message: nil, preferredStyle: .actionSheet)
+        controller.addAction(UIAlertAction(title: "Background Color", style: .default, handler: { _ in
+            self.buttonStyle = .backgroundColor
+            self.defaultOptions.transitionStyle = .border
+        }))
+        controller.addAction(UIAlertAction(title: "Circular", style: .default, handler: { _ in
+            self.buttonStyle = .circular
+            self.defaultOptions.transitionStyle = .reveal
+        }))
+        controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: nil))
+        present(controller, animated: true, completion: nil)
+        
+    }
+    
+    
+    // MARK: - Helpers
+    
+    func createSelectedBackgroundView() -> UIView {
+        let view = UIView()
+        view.backgroundColor = UIColor.lightGray.withAlphaComponent(0.2)
+        return view
+    }
+    
+    func resetData() {
+        emails = mockEmails
+        emails.forEach { $0.unread = false }
+        collectionView?.reloadData()
+    }
+}
+
+extension MailCollectionViewController: SwipeCollectionViewCellDelegate {
+    func collectionView(_ collectionView: UICollectionView, editActionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]? {
+        let email = emails[indexPath.row]
+        
+        if orientation == .left {
+            guard isSwipeRightEnabled else { return nil }
+            
+            let read = SwipeAction(style: .default, title: nil) { action, indexPath in
+                let updatedStatus = !email.unread
+                email.unread = updatedStatus
+                
+                let cell = collectionView.cellForItem(at: indexPath) as! MailCollectionViewCell
+                cell.setUnread(updatedStatus, animated: true)
+            }
+            
+            read.hidesWhenSelected = true
+            read.accessibilityLabel = email.unread ? "Mark as Read" : "Mark as Unread"
+            
+            let descriptor: ActionDescriptor = email.unread ? .read : .unread
+            configure(action: read, with: descriptor)
+            
+            return [read]
+        } else {
+            let flag = SwipeAction(style: .default, title: nil, handler: nil)
+            flag.hidesWhenSelected = true
+            configure(action: flag, with: .flag)
+            
+            let delete = SwipeAction(style: .destructive, title: nil) { action, indexPath in
+                self.emails.remove(at: indexPath.row)
+            }
+            configure(action: delete, with: .trash)
+            
+            let cell = collectionView.cellForItem(at: indexPath) as! MailCollectionViewCell
+            let closure: (UIAlertAction) -> Void = { _ in cell.hideSwipe(animated: true) }
+            let more = SwipeAction(style: .default, title: nil) { action, indexPath in
+                let controller = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+                controller.addAction(UIAlertAction(title: "Reply", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Forward", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Mark...", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Notify Me...", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Move Message...", style: .default, handler: closure))
+                controller.addAction(UIAlertAction(title: "Cancel", style: .cancel, handler: closure))
+                self.present(controller, animated: true, completion: nil)
+            }
+            configure(action: more, with: .more)
+            
+            return [delete, flag, more]
+        }
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions {
+        var options = SwipeOptions()
+        options.expansionStyle = orientation == .left ? .selection : .destructive
+        options.transitionStyle = defaultOptions.transitionStyle
+        
+        switch buttonStyle {
+        case .backgroundColor:
+            options.buttonSpacing = 11
+        case .circular:
+            options.buttonSpacing = 4
+            options.backgroundColor = #colorLiteral(red: 0.9467939734, green: 0.9468161464, blue: 0.9468042254, alpha: 1)
+        }
+        
+        return options
+    }
+    
+    func configure(action: SwipeAction, with descriptor: ActionDescriptor) {
+        action.title = descriptor.title(forDisplayMode: buttonDisplayMode)
+        action.image = descriptor.image(forStyle: buttonStyle, displayMode: buttonDisplayMode)
+        
+        switch buttonStyle {
+        case .backgroundColor:
+            action.backgroundColor = descriptor.color
+        case .circular:
+            action.backgroundColor = .clear
+            action.textColor = descriptor.color
+            action.font = .systemFont(ofSize: 13)
+            action.transitionDelegate = ScaleTransition.default
+        }
+    }
+}
+
+class MailCollectionViewCell: SwipeCollectionViewCell {
+    @IBOutlet var fromLabel: UILabel!
+    @IBOutlet var dateLabel: UILabel!
+    @IBOutlet var subjectLabel: UILabel!
+    @IBOutlet var bodyLabel: UILabel!
+    
+    var animator: Any?
+    
+    var indicatorView = IndicatorView(frame: .zero)
+    
+    var unread = false {
+        didSet {
+            indicatorView.transform = unread ? CGAffineTransform.identity : CGAffineTransform.init(scaleX: 0.001, y: 0.001)
+        }
+    }
+    
+    override func awakeFromNib() {
+        setupIndicatorView()
+    }
+    
+    func setupIndicatorView() {
+        indicatorView.translatesAutoresizingMaskIntoConstraints = false
+        indicatorView.color = tintColor
+        indicatorView.backgroundColor = .clear
+        contentView.addSubview(indicatorView)
+        
+        let size: CGFloat = 12
+        indicatorView.widthAnchor.constraint(equalToConstant: size).isActive = true
+        indicatorView.heightAnchor.constraint(equalTo: indicatorView.widthAnchor).isActive = true
+        indicatorView.leftAnchor.constraint(equalTo: contentView.leftAnchor, constant: 12).isActive = true
+        indicatorView.centerYAnchor.constraint(equalTo: fromLabel.centerYAnchor).isActive = true
+    }
+    
+    func setUnread(_ unread: Bool, animated: Bool) {
+        let closure = {
+            self.unread = unread
+        }
+        
+        if #available(iOS 10, *), animated {
+            var localAnimator = self.animator as? UIViewPropertyAnimator
+            localAnimator?.stopAnimation(true)
+            
+            localAnimator = unread ? UIViewPropertyAnimator(duration: 1.0, dampingRatio: 0.4) : UIViewPropertyAnimator(duration: 0.3, dampingRatio: 1.0)
+            localAnimator?.addAnimations(closure)
+            localAnimator?.startAnimation()
+            
+            self.animator = localAnimator
+        } else {
+            closure()
+        }
+    }
+}

--- a/Example/MailExample/MailTableViewController.swift
+++ b/Example/MailExample/MailTableViewController.swift
@@ -1,5 +1,5 @@
 //
-//  MailViewController.swift
+//  MailTableViewController.swift
 //
 //  Created by Jeremy Koch
 //  Copyright © 2017 Jeremy Koch. All rights reserved.
@@ -8,10 +8,10 @@
 import UIKit
 import SwipeCellKit
 
-class MailViewController: UITableViewController {
+class MailTableViewController: UITableViewController {
     var emails: [Email] = []
     
-    var defaultOptions = SwipeTableOptions()
+    var defaultOptions = SwipeOptions()
     var isSwipeRightEnabled = true
     var buttonDisplayMode: ButtonDisplayMode = .titleAndImage
     var buttonStyle: ButtonStyle = .backgroundColor
@@ -107,7 +107,7 @@ class MailViewController: UITableViewController {
     }
 }
 
-extension MailViewController: SwipeTableViewCellDelegate {
+extension MailTableViewController: SwipeTableViewCellDelegate {
     func tableView(_ tableView: UITableView, editActionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]? {
         let email = emails[indexPath.row]
 
@@ -157,8 +157,8 @@ extension MailViewController: SwipeTableViewCellDelegate {
         }
     }
     
-    func tableView(_ tableView: UITableView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeTableOptions {
-        var options = SwipeTableOptions()
+    func tableView(_ tableView: UITableView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions {
+        var options = SwipeOptions()
         options.expansionStyle = orientation == .left ? .selection : .destructive
         options.transitionStyle = defaultOptions.transitionStyle
         
@@ -240,62 +240,4 @@ class MailCell: SwipeTableViewCell {
             closure()
         }
     }
-}
-
-class IndicatorView: UIView {
-    var color = UIColor.clear {
-        didSet { setNeedsDisplay() }
-    }
-
-    override func draw(_ rect: CGRect) {
-        color.set()
-        UIBezierPath(ovalIn: rect).fill()
-    }
-}
-
-enum ActionDescriptor {
-    case read, unread, more, flag, trash
-    
-    func title(forDisplayMode displayMode: ButtonDisplayMode) -> String? {
-        guard displayMode != .imageOnly else { return nil }
-        
-        switch self {
-        case .read: return "Read"
-        case .unread: return "Unread"
-        case .more: return "More"
-        case .flag: return "Flag"
-        case .trash: return "Trash"
-        }
-    }
-    
-    func image(forStyle style: ButtonStyle, displayMode: ButtonDisplayMode) -> UIImage? {
-        guard displayMode != .titleOnly else { return nil }
-        
-        let name: String
-        switch self {
-        case .read: name = "Read"
-        case .unread: name = "Unread"
-        case .more: name = "More"
-        case .flag: name = "Flag"
-        case .trash: name = "Trash"
-        }
-        
-        return UIImage(named: style == .backgroundColor ? name : name + "-circle")
-    }
-    
-    var color: UIColor {
-        switch self {
-        case .read, .unread: return #colorLiteral(red: 0, green: 0.4577052593, blue: 1, alpha: 1)
-        case .more: return #colorLiteral(red: 0.7803494334, green: 0.7761332393, blue: 0.7967314124, alpha: 1)
-        case .flag: return #colorLiteral(red: 1, green: 0.5803921569, blue: 0, alpha: 1)
-        case .trash: return #colorLiteral(red: 1, green: 0.2352941176, blue: 0.1882352941, alpha: 1)
-        }
-    }
-}
-enum ButtonDisplayMode {
-    case titleAndImage, titleOnly, imageOnly
-}
-
-enum ButtonStyle {
-    case backgroundColor, circular
 }

--- a/Example/MailExample/Main.storyboard
+++ b/Example/MailExample/Main.storyboard
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11762" systemVersion="16C67" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LX8-Wu-PZs">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13771" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="LX8-Wu-PZs">
     <device id="retina5_5" orientation="portrait">
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11757"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13772"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="Segues with Peek and Pop" minToolsVersion="7.1"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -14,7 +14,7 @@
         <!--Inbox-->
         <scene sceneID="HlW-7Y-kIf">
             <objects>
-                <tableViewController id="6la-Rf-5vT" customClass="MailViewController" customModule="MailExample" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController id="6la-Rf-5vT" customClass="MailTableViewController" customModule="MailExample" customModuleProvider="target" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" rowHeight="141" sectionHeaderHeight="28" sectionFooterHeight="28" id="CnD-MW-SLC">
                         <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -24,29 +24,29 @@
                                 <rect key="frame" x="0.0" y="28" width="414" height="141"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" tableViewCell="5Yy-lT-eDE" id="4sX-Fn-82y">
-                                    <rect key="frame" x="0.0" y="0.0" width="414" height="140.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="140.66666666666666"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="QLZ-ve-Blz">
-                                            <rect key="frame" x="15" y="8" width="376" height="80.333333333333329"/>
+                                            <rect key="frame" x="20" y="8" width="366" height="42.333333333333336"/>
                                             <subviews>
                                                 <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="mEo-oH-eCL">
-                                                    <rect key="frame" x="0.0" y="0.0" width="376" height="20.333333333333332"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="366" height="20.333333333333332"/>
                                                     <subviews>
-                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="John Doe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C77-Oi-r7Y">
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="John Doe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="C77-Oi-r7Y">
                                                             <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="20.333333333333332"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                                             <nil key="textColor"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12:16 AM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MgJ-f3-Qel">
-                                                            <rect key="frame" x="81.666666666666657" y="1.3333333333333339" width="274.33333333333337" height="18"/>
+                                                            <rect key="frame" x="81.666666666666657" y="1.3333333333333339" width="264.33333333333337" height="18"/>
                                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                             <color key="textColor" red="0.40000000000000002" green="0.40000000000000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Disclosure" translatesAutoresizingMaskIntoConstraints="NO" id="UNG-rq-ulh">
-                                                            <rect key="frame" x="362" y="3.333333333333333" width="14" height="14"/>
+                                                            <rect key="frame" x="352" y="3.3333333333333339" width="14" height="14.000000000000002"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" constant="14" id="Ty6-tZ-2ee"/>
                                                                 <constraint firstAttribute="height" constant="14" id="eoh-QM-XJN"/>
@@ -55,13 +55,13 @@
                                                     </subviews>
                                                 </stackView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Fwd: Jane's independent studies" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kOp-Z7-e55">
-                                                    <rect key="frame" x="0.0" y="22.333333333333336" width="224.33333333333334" height="18.000000000000007"/>
+                                                    <rect key="frame" x="0.0" y="22.333333333333332" width="224.33333333333334" height="17.999999999999996"/>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wyD-6Z-4MU">
-                                                    <rect key="frame" x="0.0" y="42.333333333333329" width="374.66666666666669" height="37.999999999999986"/>
+                                                    <rect key="frame" x="0.0" y="42.333333333333336" width="0.0" height="0.0"/>
                                                     <string key="text">Sra. Mendez - Thank you so MUCH for this.  We know you do not have to do this and we are so grateful to you.  Please let us know if there's anything else we can do.</string>
                                                     <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                     <color key="textColor" red="0.40000000000000002" green="0.40000000000000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
@@ -112,7 +112,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="8lh-aK-vJ4" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1142.0289855072465" y="163.85869565217394"/>
+            <point key="canvasLocation" x="1616" y="-205"/>
         </scene>
         <!--View Controller-->
         <scene sceneID="17V-AF-8zo">
@@ -140,7 +140,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="pAA-dO-BBI" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1914" y="166"/>
+            <point key="canvasLocation" x="2658" y="227"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="t3H-qW-IeR">
@@ -148,7 +148,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" toolbarHidden="NO" id="LX8-Wu-PZs" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="J9z-jV-3U7">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="20" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
@@ -157,12 +157,174 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </toolbar>
                     <connections>
-                        <segue destination="6la-Rf-5vT" kind="relationship" relationship="rootViewController" id="Xt6-Od-Ddb"/>
+                        <segue destination="zFa-bd-gz6" kind="relationship" relationship="rootViewController" id="NmE-DT-0M5"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="teA-Er-8PS" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="204" y="164.16791604197903"/>
+        </scene>
+        <!--Examples-->
+        <scene sceneID="VqW-Mc-dK2">
+            <objects>
+                <tableViewController id="zFa-bd-gz6" sceneMemberID="viewController">
+                    <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="static" style="plain" separatorStyle="default" rowHeight="44" sectionHeaderHeight="28" sectionFooterHeight="28" id="nlv-ug-Fr0">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <sections>
+                            <tableViewSection id="iR0-38-MTh">
+                                <cells>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="Kgd-u6-cy7">
+                                        <rect key="frame" x="0.0" y="0.0" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="Kgd-u6-cy7" id="WoI-9A-iYC">
+                                            <rect key="frame" x="0.0" y="0.0" width="376" height="43.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="UITableView Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="kuy-3p-Gc9">
+                                                    <rect key="frame" x="8" y="11" width="164" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="6la-Rf-5vT" kind="show" id="Tj2-zz-wD5"/>
+                                        </connections>
+                                    </tableViewCell>
+                                    <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" selectionStyle="default" accessoryType="disclosureIndicator" indentationWidth="10" id="v7C-GF-bE4">
+                                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
+                                        <autoresizingMask key="autoresizingMask"/>
+                                        <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" tableViewCell="v7C-GF-bE4" id="8JL-hE-Ezo">
+                                            <rect key="frame" x="0.0" y="0.0" width="376" height="43.666666666666664"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                            <subviews>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="UICollectionView Example" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="gwd-c1-mey">
+                                                    <rect key="frame" x="8" y="11" width="199" height="21"/>
+                                                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                        </tableViewCellContentView>
+                                        <connections>
+                                            <segue destination="w79-7A-sTS" kind="show" id="z0J-zs-jgy"/>
+                                        </connections>
+                                    </tableViewCell>
+                                </cells>
+                            </tableViewSection>
+                        </sections>
+                        <connections>
+                            <outlet property="dataSource" destination="zFa-bd-gz6" id="JvE-d0-zTB"/>
+                            <outlet property="delegate" destination="zFa-bd-gz6" id="PWQ-db-uNM"/>
+                        </connections>
+                    </tableView>
+                    <navigationItem key="navigationItem" title="Examples" id="1Hr-WU-g3k"/>
+                </tableViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="C8o-Bi-5hP" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="919" y="164"/>
+        </scene>
+        <!--Mail Collection View Controller-->
+        <scene sceneID="Swv-Tr-jjC">
+            <objects>
+                <collectionViewController id="w79-7A-sTS" customClass="MailCollectionViewController" customModule="MailExample" customModuleProvider="target" sceneMemberID="viewController">
+                    <collectionView key="view" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" dataMode="prototypes" id="Nen-BV-WtC">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="736"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                        <collectionViewFlowLayout key="collectionViewLayout" minimumLineSpacing="10" minimumInteritemSpacing="10" id="Nkq-D0-kpn">
+                            <size key="itemSize" width="414" height="141"/>
+                            <size key="headerReferenceSize" width="0.0" height="0.0"/>
+                            <size key="footerReferenceSize" width="0.0" height="0.0"/>
+                            <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
+                        </collectionViewFlowLayout>
+                        <cells>
+                            <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" reuseIdentifier="MailCell" id="9DJ-7v-dYG" customClass="MailCollectionViewCell" customModule="MailExample" customModuleProvider="target">
+                                <rect key="frame" x="0.0" y="0.0" width="414" height="141"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="141"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                    <subviews>
+                                        <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="top" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="ysl-94-klK">
+                                            <rect key="frame" x="8" y="8" width="376" height="80.333333333333329"/>
+                                            <subviews>
+                                                <stackView opaque="NO" contentMode="scaleToFill" alignment="center" spacing="6" translatesAutoresizingMaskIntoConstraints="NO" id="5uQ-2a-OAe">
+                                                    <rect key="frame" x="0.0" y="0.0" width="0.0" height="20.333333333333332"/>
+                                                    <subviews>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="252" verticalHuggingPriority="251" text="John Doe" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="sfg-MB-yOh">
+                                                            <rect key="frame" x="0.0" y="0.0" width="75.666666666666671" height="20.333333333333332"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
+                                                            <nil key="textColor"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="12:16 AM" textAlignment="right" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="krw-3d-vsj">
+                                                            <rect key="frame" x="81.666666666666671" y="1.3333333333333339" width="0.0" height="18"/>
+                                                            <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                            <color key="textColor" red="0.40000000000000002" green="0.40000000000000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                            <nil key="highlightedColor"/>
+                                                        </label>
+                                                        <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Disclosure" translatesAutoresizingMaskIntoConstraints="NO" id="wgb-e1-RIb">
+                                                            <rect key="frame" x="-8" y="3.3333333333333339" width="14" height="14.000000000000002"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="14" id="9aU-Eh-pJm"/>
+                                                                <constraint firstAttribute="width" constant="14" id="ROJ-mF-KxD"/>
+                                                            </constraints>
+                                                        </imageView>
+                                                    </subviews>
+                                                </stackView>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" text="Fwd: Jane's independent studies" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3Gm-mS-pbN">
+                                                    <rect key="frame" x="0.0" y="22.333333333333332" width="224.33333333333334" height="17.999999999999996"/>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <nil key="textColor"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                                <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="pNK-Lz-z8w">
+                                                    <rect key="frame" x="0.0" y="42.333333333333336" width="0.0" height="0.0"/>
+                                                    <string key="text">Sra. Mendez - Thank you so MUCH for this.  We know you do not have to do this and we are so grateful to you.  Please let us know if there's anything else we can do.</string>
+                                                    <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
+                                                    <color key="textColor" red="0.40000000000000002" green="0.40000000000000002" blue="0.40000000000000002" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <nil key="highlightedColor"/>
+                                                </label>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="5uQ-2a-OAe" firstAttribute="width" secondItem="ysl-94-klK" secondAttribute="width" id="Wwx-s0-S19"/>
+                                            </constraints>
+                                        </stackView>
+                                    </subviews>
+                                </view>
+                                <constraints>
+                                    <constraint firstAttribute="bottomMargin" relation="greaterThanOrEqual" secondItem="ysl-94-klK" secondAttribute="bottom" constant="8" id="7RZ-B7-BUl"/>
+                                    <constraint firstItem="ysl-94-klK" firstAttribute="top" secondItem="9DJ-7v-dYG" secondAttribute="topMargin" id="ZNP-9W-lvx"/>
+                                    <constraint firstAttribute="trailingMargin" secondItem="ysl-94-klK" secondAttribute="trailing" constant="8" id="dkk-wS-IQ7"/>
+                                    <constraint firstItem="ysl-94-klK" firstAttribute="leading" secondItem="9DJ-7v-dYG" secondAttribute="leadingMargin" id="k34-IV-ciJ"/>
+                                </constraints>
+                                <connections>
+                                    <outlet property="bodyLabel" destination="pNK-Lz-z8w" id="ECM-z4-aIJ"/>
+                                    <outlet property="dateLabel" destination="krw-3d-vsj" id="F3G-ps-YmO"/>
+                                    <outlet property="fromLabel" destination="sfg-MB-yOh" id="wnE-N3-038"/>
+                                    <outlet property="subjectLabel" destination="3Gm-mS-pbN" id="uC6-1c-y7G"/>
+                                    <segue destination="81m-9H-rJk" kind="show" id="apG-D9-e8c">
+                                        <segue key="commit" inheritsFrom="parent" id="Eug-d6-ZUM"/>
+                                        <segue key="preview" inheritsFrom="commit" id="mLF-xG-omB"/>
+                                    </segue>
+                                </connections>
+                            </collectionViewCell>
+                        </cells>
+                        <connections>
+                            <outlet property="dataSource" destination="w79-7A-sTS" id="sfI-7H-L6e"/>
+                            <outlet property="delegate" destination="w79-7A-sTS" id="Xvr-IG-aHU"/>
+                        </connections>
+                    </collectionView>
+                </collectionViewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="zfN-Wd-L2x" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1615.9420289855075" y="606.52173913043487"/>
         </scene>
     </scenes>
     <resources>
@@ -170,6 +332,6 @@
         <image name="MoreOutline" width="23" height="23"/>
     </resources>
     <inferredMetricsTieBreakers>
-        <segue reference="jem-dB-OGt"/>
+        <segue reference="mLF-xG-omB"/>
     </inferredMetricsTieBreakers>
 </document>

--- a/Example/MailExample/Shared.swift
+++ b/Example/MailExample/Shared.swift
@@ -1,0 +1,67 @@
+//
+//  Shared.swift
+//  MailExample
+//
+//  Created by Jeremy Koch
+//  Copyright © 2017 Jeremy Koch. All rights reserved.
+//
+
+import UIKit
+
+class IndicatorView: UIView {
+    var color = UIColor.clear {
+        didSet { setNeedsDisplay() }
+    }
+    
+    override func draw(_ rect: CGRect) {
+        color.set()
+        UIBezierPath(ovalIn: rect).fill()
+    }
+}
+
+enum ActionDescriptor {
+    case read, unread, more, flag, trash
+    
+    func title(forDisplayMode displayMode: ButtonDisplayMode) -> String? {
+        guard displayMode != .imageOnly else { return nil }
+        
+        switch self {
+        case .read: return "Read"
+        case .unread: return "Unread"
+        case .more: return "More"
+        case .flag: return "Flag"
+        case .trash: return "Trash"
+        }
+    }
+    
+    func image(forStyle style: ButtonStyle, displayMode: ButtonDisplayMode) -> UIImage? {
+        guard displayMode != .titleOnly else { return nil }
+        
+        let name: String
+        switch self {
+        case .read: name = "Read"
+        case .unread: name = "Unread"
+        case .more: name = "More"
+        case .flag: name = "Flag"
+        case .trash: name = "Trash"
+        }
+        
+        return UIImage(named: style == .backgroundColor ? name : name + "-circle")
+    }
+    
+    var color: UIColor {
+        switch self {
+        case .read, .unread: return #colorLiteral(red: 0, green: 0.4577052593, blue: 1, alpha: 1)
+        case .more: return #colorLiteral(red: 0.7803494334, green: 0.7761332393, blue: 0.7967314124, alpha: 1)
+        case .flag: return #colorLiteral(red: 1, green: 0.5803921569, blue: 0, alpha: 1)
+        case .trash: return #colorLiteral(red: 1, green: 0.2352941176, blue: 0.1882352941, alpha: 1)
+        }
+    }
+}
+enum ButtonDisplayMode {
+    case titleAndImage, titleOnly, imageOnly
+}
+
+enum ButtonStyle {
+    case backgroundColor, circular
+}

--- a/Source/Extensions.swift
+++ b/Source/Extensions.swift
@@ -17,6 +17,24 @@ extension UITableView {
     }
 }
 
+extension UICollectionView {
+    var swipeCells: [SwipeCollectionViewCell] {
+        return visibleCells as? [SwipeCollectionViewCell] ?? []
+    }
+    
+    func hideSwipeCell() {
+        swipeCells.forEach { $0.hideSwipe(animated: true) }
+    }
+    
+    func setGestureEnabled(_ enabled: Bool) {
+        gestureRecognizers?.forEach {
+            guard $0 != panGestureRecognizer else { return }
+            
+            $0.isEnabled = enabled
+        }
+    }
+}
+
 extension UIPanGestureRecognizer {
     func elasticTranslation(in view: UIView?, withLimit limit: CGSize, fromOriginalCenter center: CGPoint, applyingRatio ratio: CGFloat = 0.20) -> CGPoint {
         let translation = self.translation(in: view)

--- a/Source/SwipeAccessibilityCustomAction.swift
+++ b/Source/SwipeAccessibilityCustomAction.swift
@@ -1,0 +1,25 @@
+//
+//  SwipeAccessibilityCustomAction.swift
+//  SwipeCellKit
+//
+//  Created by Jeremy Koch
+//  Copyright © 2017 Jeremy Koch. All rights reserved.
+//
+
+import UIKit
+
+class SwipeAccessibilityCustomAction: UIAccessibilityCustomAction {
+    let action: SwipeAction
+    let indexPath: IndexPath
+    
+    init(action: SwipeAction, indexPath: IndexPath, target: Any, selector: Selector) {
+        guard let name = action.accessibilityLabel ?? action.title ?? action.image?.accessibilityIdentifier else {
+            fatalError("You must provide either a title or an image for a SwipeAction")
+        }
+        
+        self.action = action
+        self.indexPath = indexPath
+        
+        super.init(name: name, target: target, selector: selector)
+    }
+}

--- a/Source/SwipeAction.swift
+++ b/Source/SwipeAction.swift
@@ -17,9 +17,9 @@ public enum SwipeActionStyle: Int {
 }
 
 /**
- The `SwipeAction` object defines a single action to present when the user swipes horizontally in a table row.
+ The `SwipeAction` object defines a single action to present when the user swipes horizontally in a table/collection item.
  
- This class lets you define one or more custom actions to display for a given row in your table. Each instance of this class represents a single action to perform and includes the text, formatting information, and behavior for the corresponding button.
+ This class lets you define one or more custom actions to display for a given item in your table/collection. Each instance of this class represents a single action to perform and includes the text, formatting information, and behavior for the corresponding button.
  */
 public class SwipeAction: NSObject {
     /// An optional unique action identifier.

--- a/Source/SwipeActionsView.swift
+++ b/Source/SwipeActionsView.swift
@@ -27,7 +27,7 @@ class SwipeActionsView: UIView {
 
     let orientation: SwipeActionsOrientation
     let actions: [SwipeAction]
-    let options: SwipeTableOptions
+    let options: SwipeOptions
     
     var buttons: [SwipeActionButton] = []
     
@@ -71,7 +71,7 @@ class SwipeActionsView: UIView {
         return options.expansionStyle != nil ? actions.last : nil
     }
     
-    init(maxSize: CGSize, options: SwipeTableOptions, orientation: SwipeActionsOrientation, actions: [SwipeAction]) {
+    init(maxSize: CGSize, options: SwipeOptions, orientation: SwipeActionsOrientation, actions: [SwipeAction]) {
         self.options = options
         self.orientation = orientation
         self.actions = actions.reversed()
@@ -148,7 +148,7 @@ class SwipeActionsView: UIView {
         delegate?.swipeActionsView(self, didSelect: actions[index])
     }
     
-    func buttonEdgeInsets(fromOptions options: SwipeTableOptions) -> UIEdgeInsets {
+    func buttonEdgeInsets(fromOptions options: SwipeOptions) -> UIEdgeInsets {
         let padding = options.buttonPadding ?? 8
         return UIEdgeInsets(top: padding, left: padding, bottom: padding, right: padding)
     }

--- a/Source/SwipeCollectionViewCell+Accessibility.swift
+++ b/Source/SwipeCollectionViewCell+Accessibility.swift
@@ -1,5 +1,5 @@
 //
-//  SwipeTableViewCell+Accessibility.swift
+//  SwipeCollectionViewCell+Accessibility.swift
 //
 //  Created by Jeremy Koch
 //  Copyright © 2017 Jeremy Koch. All rights reserved.
@@ -7,13 +7,13 @@
 
 import UIKit
 
-extension SwipeTableViewCell {
+extension SwipeCollectionViewCell {
     /// :nodoc:
     open override func accessibilityElementCount() -> Int {
         guard state != .center else {
             return super.accessibilityElementCount()
         }
-
+        
         return 1
     }
     
@@ -22,7 +22,7 @@ extension SwipeTableViewCell {
         guard state != .center else {
             return super.accessibilityElement(at: index)
         }
-
+        
         return actionsView
     }
     
@@ -31,21 +31,21 @@ extension SwipeTableViewCell {
         guard state != .center else {
             return super.index(ofAccessibilityElement: element)
         }
-
+        
         return element is SwipeActionsView ? 0 : NSNotFound
     }
 }
 
-extension SwipeTableViewCell {
+extension SwipeCollectionViewCell {
     /// :nodoc:
     open override var accessibilityCustomActions: [UIAccessibilityCustomAction]? {
         get {
-            guard let tableView = tableView, let indexPath = tableView.indexPath(for: self) else {
+            guard let collectionView = collectionView, let indexPath = collectionView.indexPath(for: self) else {
                 return super.accessibilityCustomActions
             }
             
-            let leftActions = delegate?.tableView(tableView, editActionsForRowAt: indexPath, for: .left) ?? []
-            let rightActions = delegate?.tableView(tableView, editActionsForRowAt: indexPath, for: .right) ?? []
+            let leftActions = delegate?.collectionView(collectionView, editActionsForRowAt: indexPath, for: .left) ?? []
+            let rightActions = delegate?.collectionView(collectionView, editActionsForRowAt: indexPath, for: .right) ?? []
             
             let actions = [rightActions.first, leftActions.first].flatMap({ $0 }) + rightActions.dropFirst() + leftActions.dropFirst()
             
@@ -65,14 +65,14 @@ extension SwipeTableViewCell {
     }
     
     @objc func performAccessibilityCustomAction(accessibilityCustomAction: SwipeAccessibilityCustomAction) -> Bool {
-        guard let tableView = tableView else { return false }
+        guard let collectionView = collectionView else { return false }
         
         let swipeAction = accessibilityCustomAction.action
         
         swipeAction.handler?(swipeAction, accessibilityCustomAction.indexPath)
         
         if swipeAction.style == .destructive {
-            tableView.deleteRows(at: [accessibilityCustomAction.indexPath], with: .fade)
+            collectionView.deleteItems(at: [accessibilityCustomAction.indexPath])
         }
         
         return true

--- a/Source/SwipeCollectionViewCell+Display.swift
+++ b/Source/SwipeCollectionViewCell+Display.swift
@@ -1,0 +1,99 @@
+//
+//  SwipeCollectionViewCell+Display.swift
+//
+//  Created by Jeremy Koch
+//  Copyright © 2017 Jeremy Koch. All rights reserved.
+//
+
+import UIKit
+
+extension SwipeCollectionViewCell {
+    /// The point at which the origin of the cell is offset from the non-swiped origin.
+    public var swipeOffset: CGFloat {
+        set { setSwipeOffset(newValue, animated: false) }
+        get { return contentView.frame.midX - bounds.midX }
+    }
+    
+    /**
+     Hides the swipe actions and returns the cell to center.
+     
+     - parameter animated: Specify `true` to animate the hiding of the swipe actions or `false` to hide it immediately.
+     
+     - parameter completion: The closure to be executed once the animation has finished. A `Boolean` argument indicates whether or not the animations actually finished before the completion handler was called.
+     */
+    public func hideSwipe(animated: Bool, completion: ((Bool) -> Void)? = nil) {
+        guard state == .left || state == .right else { return }
+        
+        state = .animatingToCenter
+        
+        let targetCenter = self.targetCenter(active: false)
+        
+        if animated {
+            animate(toOffset: targetCenter) { complete in
+                self.reset()
+                completion?(complete)
+            }
+        } else {
+            contentViewCenter = CGPoint(x: targetCenter, y: contentViewCenter.y)
+            reset()
+        }
+        
+        notifyEditingStateChange(active: false)
+    }
+    
+    /**
+     Shows the swipe actions for the specified orientation.
+     
+     - parameter orientation: The side of the cell on which to show the swipe actions.
+     
+     - parameter animated: Specify `true` to animate the showing of the swipe actions or `false` to show them immediately.
+     
+     - parameter completion: The closure to be executed once the animation has finished. A `Boolean` argument indicates whether or not the animations actually finished before the completion handler was called.
+     */
+    public func showSwipe(orientation: SwipeActionsOrientation, animated: Bool = true, completion: ((Bool) -> Void)? = nil) {
+        setSwipeOffset(.greatestFiniteMagnitude * orientation.scale * -1,
+                       animated: animated,
+                       completion: completion)
+    }
+    
+    /**
+     The point at which the origin of the cell is offset from the non-swiped origin.
+     
+     - parameter offset: A point (expressed in points) that is offset from the non-swiped origin.
+     
+     - parameter animated: Specify `true` to animate the transition to the new offset, `false` to make the transition immediate.
+     
+     - parameter completion: The closure to be executed once the animation has finished. A `Boolean` argument indicates whether or not the animations actually finished before the completion handler was called.
+     */
+    public func setSwipeOffset(_ offset: CGFloat, animated: Bool = true, completion: ((Bool) -> Void)? = nil) {
+        guard offset != 0 else {
+            hideSwipe(animated: animated, completion: completion)
+            return
+        }
+        
+        let targetOrientation: SwipeActionsOrientation = offset > 0 ? .left : .right
+        let targetState = SwipeState(orientation: targetOrientation)
+        
+        if state != targetState {
+            if orientation != targetOrientation {
+                guard showActionsView(for: targetOrientation) else { return }
+                orientation = targetOrientation
+            }
+            
+            collectionView?.hideSwipeCell()
+            
+            state = targetState
+        }
+        
+        let maxOffset = min(bounds.width, abs(offset)) * -targetOrientation.scale
+        let targetCenter = abs(offset) == CGFloat.greatestFiniteMagnitude ? self.targetCenter(active: true) : bounds.midX + maxOffset
+        
+        if animated {
+            animate(toOffset: targetCenter) { complete in
+                completion?(complete)
+            }
+        } else {
+            contentViewCenter.x = targetCenter
+        }
+    }
+}

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -459,19 +459,19 @@ extension SwipeCollectionViewCell: SwipeActionsViewDelegate {
             
             switch style {
             case .delete:
-                self?.mask = actionsView.createDeletionMask()
+                self?.contentView.mask = actionsView.createDeletionMask()
                 
                 collectionView.deleteItems(at: [indexPath])
                 
                 UIView.animate(withDuration: 0.3, animations: {
                     self?.contentViewCenter.x = newCenter
-                    self?.mask?.frame.size.height = 0
+                    self?.contentView.mask?.frame.size.height = 0
                     
                     if fillOption.timing == .after {
                         actionsView.alpha = 0
                     }
                 }) { [weak self] _ in
-                    self?.mask = nil
+                    self?.contentView.mask = nil
                     self?.reset()
                 }
             case .reset:

--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -1,5 +1,6 @@
 //
-//  SwipeTableViewCell.swift
+//  SwipeCollectionViewCell.swift
+//  SwipeCellKit
 //
 //  Created by Jeremy Koch
 //  Copyright © 2017 Jeremy Koch. All rights reserved.
@@ -8,23 +9,24 @@
 import UIKit
 
 /**
- The `SwipeTableViewCell` class extends `UITableViewCell` and provides more flexible options for cell swiping behavior.
+ The `SwipeCollectionViewCell` class extends `UICollectionViewCell` and provides more flexible options for cell swiping behavior.
  
  
- The default behavior closely matches the stock Mail.app. If you want to customize the transition style (ie. how the action buttons are exposed), or the expansion style (the behavior when the row is swiped passes a defined threshold), you can return the appropriately configured `SwipeOptions` via the `SwipeTableViewCellDelegate` delegate.
+ The default behavior closely matches the stock Mail.app. If you want to customize the transition style (ie. how the action buttons are exposed), or the expansion style (the behavior when the row is swiped passes a defined threshold), you can return the appropriately configured `SwipeOptions` via the `SwipeCollectionViewCellDelegate` delegate.
  */
-open class SwipeTableViewCell: UITableViewCell {
-    /// The object that acts as the delegate of the `SwipeTableViewCell`.
-    public weak var delegate: SwipeTableViewCellDelegate?
+open class SwipeCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate {
+    /// The object that acts as the delegate of the `SwipeCollectionViewCell`.
+    public weak var delegate: SwipeCollectionViewCellDelegate?
     
     var animator: SwipeAnimator?
-
+    
     var state = SwipeState.center
+    var orientation: SwipeActionsOrientation?
     var originalCenter: CGFloat = 0
     
-    weak var tableView: UITableView?
+    weak var collectionView: UICollectionView?
     var actionsView: SwipeActionsView?
-
+    
     var originalLayoutMargins: UIEdgeInsets = .zero
     
     lazy var panGestureRecognizer: UIPanGestureRecognizer = {
@@ -41,11 +43,11 @@ open class SwipeTableViewCell: UITableViewCell {
     
     let elasticScrollRatio: CGFloat = 0.4
     var scrollRatio: CGFloat = 1.0
-    
-    /// :nodoc:
-    override open var center: CGPoint {
-        didSet {
-            actionsView?.visibleWidth = abs(frame.minX)
+    var contentViewCenter: CGPoint {
+        get { return contentView.center }
+        set {
+            contentView.center = newValue
+            actionsView?.visibleWidth = abs(contentView.frame.minX)
         }
     }
     
@@ -56,8 +58,17 @@ open class SwipeTableViewCell: UITableViewCell {
     }
     
     /// :nodoc:
-    override public init(style: UITableViewCellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    open override var isHighlighted: Bool {
+        set {
+            guard state == .center else { return }
+            super.isHighlighted = newValue
+        }
+        get { return super.isHighlighted }
+    }
+    
+    /// :nodoc:
+    override public init(frame: CGRect) {
+        super.init(frame: frame)
         
         configure()
     }
@@ -70,14 +81,14 @@ open class SwipeTableViewCell: UITableViewCell {
     }
     
     deinit {
-        tableView?.panGestureRecognizer.removeTarget(self, action: nil)
+        collectionView?.panGestureRecognizer.removeTarget(self, action: nil)
     }
     
     func configure() {
-        clipsToBounds = false
+        contentView.clipsToBounds = false
         
-        addGestureRecognizer(tapGestureRecognizer)
-        addGestureRecognizer(panGestureRecognizer)
+        contentView.addGestureRecognizer(tapGestureRecognizer)
+        contentView.addGestureRecognizer(panGestureRecognizer)
     }
     
     /// :nodoc:
@@ -95,89 +106,90 @@ open class SwipeTableViewCell: UITableViewCell {
         while let superview = view.superview {
             view = superview
             
-            if let tableView = view as? UITableView {
-                self.tableView = tableView
+            if let collectionView = view as? UICollectionView {
+                self.collectionView = collectionView
                 
-                tableView.panGestureRecognizer.removeTarget(self, action: nil)
-                tableView.panGestureRecognizer.addTarget(self, action: #selector(handleTablePan(gesture:)))
+                collectionView.panGestureRecognizer.removeTarget(self, action: nil)
+                collectionView.panGestureRecognizer.addTarget(self, action: #selector(handleCollectionPan(gesture:)))
                 return
-            }            
+            }
         }
     }
     
     /// :nodoc:
-    override open func setEditing(_ editing: Bool, animated: Bool) {
-        super.setEditing(editing, animated: animated)
+    open override func willMove(toWindow newWindow: UIWindow?) {
+        super.willMove(toWindow: newWindow)
         
-        if editing {
-            hideSwipe(animated: false)
+        if newWindow == nil {
+            reset()
         }
     }
     
     @objc func handlePan(gesture: UIPanGestureRecognizer) {
-        guard isEditing == false else { return }
         guard let target = gesture.view else { return }
         
         switch gesture.state {
         case .began:
             stopAnimatorIfNeeded()
-
-            originalCenter = center.x
+            
+            // Use contentViewCenter.x instead of center.x so that it's relative only to the cell bounds, and
+            //   not the overall collection view's interpretation of the cell's center
+            originalCenter = contentViewCenter.x
             
             if state == .center || state == .animatingToCenter {
                 let velocity = gesture.velocity(in: target)
                 let orientation: SwipeActionsOrientation = velocity.x > 0 ? .left : .right
-
+                
                 showActionsView(for: orientation)
+                self.orientation = orientation
             }
             
         case .changed:
             guard let actionsView = actionsView else { return }
-
+            
             let translation = gesture.translation(in: target).x
             scrollRatio = 1.0
             
             // Check if dragging past the center of the opposite direction of action view, if so
             // then we need to apply elasticity
             if (translation + originalCenter - bounds.midX) * actionsView.orientation.scale > 0 {
-                target.center.x = gesture.elasticTranslation(in: target,
-                                                             withLimit: .zero,
-                                                             fromOriginalCenter: CGPoint(x: originalCenter, y: 0)).x
+                contentViewCenter.x = gesture.elasticTranslation(in: contentView,
+                                                                 withLimit: .zero,
+                                                                 fromOriginalCenter: CGPoint(x: originalCenter, y: 0)).x
                 scrollRatio = elasticScrollRatio
                 return
             }
             
             if let expansionStyle = actionsView.options.expansionStyle {
-                let expanded = expansionStyle.shouldExpand(view: self, gesture: gesture, in: tableView!)
+                let expanded = expansionStyle.shouldExpand(view: self, gesture: gesture, in: collectionView!, usingFrame: contentView.frame)
                 let targetOffset = expansionStyle.targetOffset(for: self)
                 let currentOffset = abs(translation + originalCenter - bounds.midX)
                 
                 if expanded && !actionsView.expanded && targetOffset > currentOffset {
                     let centerForTranslationToEdge = bounds.midX - targetOffset * actionsView.orientation.scale
                     let delta = centerForTranslationToEdge - originalCenter
-                    
                     animate(toOffset: centerForTranslationToEdge)
                     gesture.setTranslation(CGPoint(x: delta, y: 0), in: superview!)
                 } else {
-                    target.center.x = gesture.elasticTranslation(in: target,
-                                                                 withLimit: CGSize(width: targetOffset, height: 0),
-                                                                 fromOriginalCenter: CGPoint(x: originalCenter, y: 0),
-                                                                 applyingRatio: expansionStyle.targetOverscrollElasticity).x
+                    contentViewCenter.x = gesture.elasticTranslation(in: contentView,
+                                                                     withLimit: CGSize(width: targetOffset, height: 0),
+                                                                     fromOriginalCenter: CGPoint(x: originalCenter, y: 0),
+                                                                     applyingRatio: expansionStyle.targetOverscrollElasticity).x
                 }
                 
                 actionsView.setExpanded(expanded: expanded, feedback: true)
             } else {
-                target.center.x = gesture.elasticTranslation(in: target,
-                                                             withLimit: CGSize(width: actionsView.preferredWidth, height: 0),
-                                                             fromOriginalCenter: CGPoint(x: originalCenter, y: 0),
-                                                             applyingRatio: elasticScrollRatio).x
-                if (target.center.x - originalCenter) / translation != 1.0 {
+                contentViewCenter.x = gesture.elasticTranslation(in: contentView,
+                                                                 withLimit: CGSize(width: actionsView.preferredWidth, height: 0),
+                                                                 fromOriginalCenter: CGPoint(x: originalCenter, y: 0),
+                                                                 applyingRatio: elasticScrollRatio).x
+                if (contentViewCenter.x - originalCenter) / translation != 1.0 {
                     scrollRatio = elasticScrollRatio
                 }
             }
         case .ended:
             guard let actionsView = actionsView else { return }
-
+            
             let velocity = gesture.velocity(in: target)
             state = targetState(forVelocity: velocity)
             
@@ -185,29 +197,29 @@ open class SwipeTableViewCell: UITableViewCell {
                 perform(action: expandedAction)
             } else {
                 let targetOffset = targetCenter(active: state.isActive)
-                let distance = targetOffset - center.x
+                let distance = targetOffset - contentViewCenter.x
                 let normalizedVelocity = velocity.x * scrollRatio / distance
-
+                
                 animate(toOffset: targetOffset, withInitialVelocity: normalizedVelocity) { _ in
                     if self.state == .center {
                         self.reset()
                     }
                 }
-
+                
                 if !state.isActive {
                     notifyEditingStateChange(active: false)
                 }
             }
-
+            
         default: break
         }
     }
     
     @discardableResult
     func showActionsView(for orientation: SwipeActionsOrientation) -> Bool {
-        guard let tableView = tableView,
-            let indexPath = tableView.indexPath(for: self),
-            let actions = delegate?.tableView(tableView, editActionsForRowAt: indexPath, for: orientation),
+        guard let collectionView = collectionView,
+            let indexPath = collectionView.indexPath(for: self),
+            let actions = delegate?.collectionView(collectionView, editActionsForRowAt: indexPath, for: orientation),
             actions.count > 0
             else {
                 return false
@@ -216,20 +228,21 @@ open class SwipeTableViewCell: UITableViewCell {
         originalLayoutMargins = super.layoutMargins
         
         // Remove highlight and deselect any selected cells
-        super.setHighlighted(false, animated: false)
-        let selectedIndexPaths = tableView.indexPathsForSelectedRows
-        selectedIndexPaths?.forEach { tableView.deselectRow(at: $0, animated: false) }
+        isHighlighted = false
+        let selectedIndexPaths = collectionView.indexPathsForSelectedItems
+        selectedIndexPaths?.forEach { collectionView.deselectItem(at: $0, animated: false) }
         
         configureActionsView(with: actions, for: orientation)
+        self.orientation = orientation
         
         return true
     }
     
     func configureActionsView(with actions: [SwipeAction], for orientation: SwipeActionsOrientation) {
-        guard let tableView = tableView,
-            let indexPath = tableView.indexPath(for: self) else { return }
+        guard let collectionView = collectionView,
+            let indexPath = collectionView.indexPath(for: self) else { return }
         
-        let options = delegate?.tableView(tableView, editActionsOptionsForRowAt: indexPath, for: orientation) ?? SwipeOptions()
+        let options = delegate?.collectionView(collectionView, editActionsOptionsForRowAt: indexPath, for: orientation) ?? SwipeOptions()
         
         self.actionsView?.removeFromSuperview()
         self.actionsView = nil
@@ -241,22 +254,20 @@ open class SwipeTableViewCell: UITableViewCell {
         
         actionsView.delegate = self
         
-        addSubview(actionsView)
-
+        contentView.addSubview(actionsView)
+        
         actionsView.heightAnchor.constraint(equalTo: heightAnchor).isActive = true
         actionsView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 2).isActive = true
         actionsView.topAnchor.constraint(equalTo: topAnchor).isActive = true
         
         if orientation == .left {
-            actionsView.rightAnchor.constraint(equalTo: leftAnchor).isActive = true
+            actionsView.rightAnchor.constraint(equalTo: contentView.leftAnchor).isActive = true
         } else {
-            actionsView.leftAnchor.constraint(equalTo: rightAnchor).isActive = true
+            actionsView.leftAnchor.constraint(equalTo: contentView.rightAnchor).isActive = true
         }
-		
-		actionsView.setNeedsUpdateConstraints()
-		
-		self.actionsView = actionsView
-
+        
+        self.actionsView = actionsView
+        
         state = .dragging
         
         notifyEditingStateChange(active: true)
@@ -264,13 +275,13 @@ open class SwipeTableViewCell: UITableViewCell {
     
     func notifyEditingStateChange(active: Bool) {
         guard let actionsView = actionsView,
-            let tableView = tableView,
-            let indexPath = tableView.indexPath(for: self) else { return }
-
+            let collectionView = collectionView,
+            let indexPath = collectionView.indexPath(for: self) else { return }
+        
         if active {
-            delegate?.tableView(tableView, willBeginEditingRowAt: indexPath, for: actionsView.orientation)
+            delegate?.collectionView(collectionView, willBeginEditingRowAt: indexPath, for: actionsView.orientation)
         } else {
-            delegate?.tableView(tableView, didEndEditingRowAt: indexPath, for: actionsView.orientation)
+            delegate?.collectionView(collectionView, didEndEditingRowAt: indexPath, for: actionsView.orientation)
         }
     }
     
@@ -296,9 +307,9 @@ open class SwipeTableViewCell: UITableViewCell {
                 }
             }
         }()
-
+        
         animator.addAnimations({
-            self.center = CGPoint(x: offset, y: self.center.y)
+            self.contentViewCenter = CGPoint(x: offset, y: self.contentViewCenter.y)
             
             self.layoutIfNeeded()
         })
@@ -308,7 +319,7 @@ open class SwipeTableViewCell: UITableViewCell {
         }
         
         self.animator = animator
-
+        
         animator.startAnimation()
     }
     
@@ -317,30 +328,30 @@ open class SwipeTableViewCell: UITableViewCell {
             animator?.stopAnimation(true)
         }
     }
-
+    
     @objc func handleTap(gesture: UITapGestureRecognizer) {
         hideSwipe(animated: true)
     }
     
-    @objc func handleTablePan(gesture: UIPanGestureRecognizer) {
+    @objc func handleCollectionPan(gesture: UIPanGestureRecognizer) {
         if gesture.state == .began {
             hideSwipe(animated: true)
         }
     }
     
-    // Override so we can accept touches anywhere within the cell's minY/maxY.
+    // Override so we can accept touches anywhere within the cell's original frame.
     // This is required to detect touches on the `SwipeActionsView` sitting alongside the
-    // `SwipeTableCell`.
+    // `SwipeCollectionViewCell`.
     /// :nodoc:
     override open func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
         guard let superview = superview else { return false }
-     
+        
         let point = convert(point, to: superview)
-
+        
         if !UIAccessibilityIsVoiceOverRunning() {
-            for cell in tableView?.swipeCells ?? [] {
+            for cell in collectionView?.swipeCells ?? [] {
                 if (cell.state == .left || cell.state == .right) && !cell.contains(point: point) {
-                    tableView?.hideSwipeCell()
+                    collectionView?.hideSwipeCell()
                     return false
                 }
             }
@@ -350,15 +361,18 @@ open class SwipeTableViewCell: UITableViewCell {
     }
     
     func contains(point: CGPoint) -> Bool {
-        return point.y > frame.minY && point.y < frame.maxY
+        return frame.contains(point)
     }
     
-    /// :nodoc:
-    override open func setHighlighted(_ highlighted: Bool, animated: Bool) {
-        if state == .center {
-            super.setHighlighted(highlighted, animated: animated)
-        }
+    // Override hitTest(_:with:) here so that we can make sure our `actionsView` gets the touch event
+    //   if it's supposed to, since otherwise, our `contentView` will swallow it and pass it up to
+    //   the collection view.
+    open override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
+        guard let actionsView = actionsView else { return super.hitTest(point, with: event) }
+        let modifiedPoint = actionsView.convert(point, from: self)
+        return actionsView.hitTest(modifiedPoint, with: event) ?? super.hitTest(point, with: event)
     }
+
     
     /// :nodoc:
     override open var layoutMargins: UIEdgeInsets {
@@ -371,7 +385,7 @@ open class SwipeTableViewCell: UITableViewCell {
     }
 }
 
-extension SwipeTableViewCell {
+extension SwipeCollectionViewCell {
     func targetState(forVelocity velocity: CGPoint) -> SwipeState {
         guard let actionsView = actionsView else { return .center }
         
@@ -385,19 +399,20 @@ extension SwipeTableViewCell {
     
     func targetCenter(active: Bool) -> CGFloat {
         guard let actionsView = actionsView, active == true else { return bounds.midX }
-
         return bounds.midX - actionsView.preferredWidth * actionsView.orientation.scale
     }
-
+    
     func reset() {
         state = .center
-        clipsToBounds = false
+        
+        collectionView?.setGestureEnabled(true)
+        
         actionsView?.removeFromSuperview()
         actionsView = nil
     }
 }
 
-extension SwipeTableViewCell: SwipeActionsViewDelegate {
+extension SwipeCollectionViewCell: SwipeActionsViewDelegate {
     func swipeActionsView(_ swipeActionsView: SwipeActionsView, didSelect action: SwipeAction) {
         perform(action: action)
     }
@@ -408,21 +423,21 @@ extension SwipeTableViewCell: SwipeActionsViewDelegate {
         if action == actionsView.expandableAction, let expansionStyle = actionsView.options.expansionStyle {
             // Trigger the expansion (may already be expanded from drag)
             actionsView.setExpanded(expanded: true)
-
+            
             switch expansionStyle.completionAnimation {
             case .bounce:
                 perform(action: action, hide: true)
             case .fill(let fillOption):
                 performFillAction(action: action, fillOption: fillOption)
-            }            
+            }
         } else {
             perform(action: action, hide: action.hidesWhenSelected)
         }
     }
     
     func perform(action: SwipeAction, hide: Bool) {
-        guard let tableView = tableView, let indexPath = tableView.indexPath(for: self) else { return }
-
+        guard let collectionView = collectionView, let indexPath = collectionView.indexPath(for: self) else { return }
+        
         if hide {
             hideSwipe(animated: true)
         }
@@ -432,24 +447,24 @@ extension SwipeTableViewCell: SwipeActionsViewDelegate {
     
     func performFillAction(action: SwipeAction, fillOption: SwipeExpansionStyle.FillOptions) {
         guard let actionsView = actionsView,
-            let tableView = tableView,
-            let indexPath = tableView.indexPath(for: self) else { return }
+            let collectionView = collectionView,
+            let indexPath = collectionView.indexPath(for: self) else { return }
         
         let newCenter = bounds.midX - (bounds.width + actionsView.minimumButtonWidth) * actionsView.orientation.scale
-
+        
         action.completionHandler = { [weak self] style in
             action.completionHandler = nil
-
-            self?.delegate?.tableView(tableView, didEndEditingRowAt: indexPath, for: actionsView.orientation)
+            
+            self?.delegate?.collectionView(collectionView, didEndEditingRowAt: indexPath, for: actionsView.orientation)
             
             switch style {
             case .delete:
                 self?.mask = actionsView.createDeletionMask()
                 
-                tableView.deleteRows(at: [indexPath], with: .none)
+                collectionView.deleteItems(at: [indexPath])
                 
                 UIView.animate(withDuration: 0.3, animations: {
-                    self?.center.x = newCenter
+                    self?.contentViewCenter.x = newCenter
                     self?.mask?.frame.size.height = 0
                     
                     if fillOption.timing == .after {
@@ -484,26 +499,28 @@ extension SwipeTableViewCell: SwipeActionsViewDelegate {
     }
 }
 
-extension SwipeTableViewCell {
+extension SwipeCollectionViewCell {
     /// :nodoc:
     override open func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
         if gestureRecognizer == tapGestureRecognizer {
             if UIAccessibilityIsVoiceOverRunning() {
-                tableView?.hideSwipeCell()
+                collectionView?.hideSwipeCell()
             }
-
-            let cell = tableView?.swipeCells.first(where: { $0.state.isActive })
-            return cell == nil ? false : true
+            
+            if let cells = collectionView?.visibleCells as? [SwipeCollectionViewCell] {
+                let cell = cells.first(where: { $0.state.isActive })
+                return cell == nil ? false : true
+            }
         }
         
         if gestureRecognizer == panGestureRecognizer,
             let view = gestureRecognizer.view,
-            let gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer
-        {
+            let gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer {
             let translation = gestureRecognizer.translation(in: view)
             return abs(translation.y) <= abs(translation.x)
         }
-
+        
         return true
     }
 }
+

--- a/Source/SwipeCollectionViewCellDelegate.swift
+++ b/Source/SwipeCollectionViewCellDelegate.swift
@@ -1,0 +1,76 @@
+//
+//  SwipeCollectionViewCellDelegate.swift
+//
+//  Created by Jeremy Koch
+//  Copyright © 2017 Jeremy Koch. All rights reserved.
+//
+
+import UIKit
+
+/**
+ The `SwipeCollectionViewCellDelegate` protocol is adopted by an object that manages the display of action buttons when the cell is swiped.
+ */
+public protocol SwipeCollectionViewCellDelegate: class {
+    /**
+     Asks the delegate for the actions to display in response to a swipe in the specified row.
+     
+     - parameter collectionView: The collection view object which owns the cell requesting this information.
+     
+     - parameter indexPath: The index path of the row.
+     
+     - parameter orientation: The side of the cell requesting this information.
+     
+     - returns: An array of `SwipeAction` objects representing the actions for the row. Each action you provide is used to create a button that the user can tap.  Returning `nil` will prevent swiping for the supplied orientation.
+     */
+    func collectionView(_ collectionView: UICollectionView, editActionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> [SwipeAction]?
+    
+    /**
+     Asks the delegate for the display options to be used while presenting the action buttons.
+     
+     - parameter collectionView: The collection view object which owns the cell requesting this information.
+     
+     - parameter indexPath: The index path of the row.
+     
+     - parameter orientation: The side of the cell requesting this information.
+     
+     - returns: A `SwipeOptions` instance which configures the behavior of the action buttons.
+     
+     - note: If not implemented, a default `SwipeOptions` instance is used.
+     */
+    func collectionView(_ collectionView: UICollectionView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions
+    
+    /**
+     Tells the delegate that the collection view is about to go into editing mode.
+     
+     - parameter collectionView: The collection view object providing this information.
+     
+     - parameter indexPath: The index path of the row.
+     
+     - parameter orientation: The side of the cell.
+     */
+    func collectionView(_ collectionView: UICollectionView, willBeginEditingRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation)
+    
+    /**
+     Tells the delegate that the collection view has left editing mode.
+     
+     - parameter collectionView: The collection view object providing this information.
+     
+     - parameter indexPath: The index path of the row.
+     
+     - parameter orientation: The side of the cell.
+     */
+    func collectionView(_ collectionView: UICollectionView, didEndEditingRowAt indexPath: IndexPath?, for orientation: SwipeActionsOrientation)
+}
+
+/**
+ Default implementation of `SwipeCollectionViewCellDelegate` methods
+ */
+public extension SwipeCollectionViewCellDelegate {
+    func collectionView(_ collectionView: UICollectionView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions {
+        return SwipeOptions()
+    }
+    
+    func collectionView(_ collectionView: UICollectionView, willBeginEditingRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) {}
+    
+    func collectionView(_ collectionView: UICollectionView, didEndEditingRowAt indexPath: IndexPath?, for orientation: SwipeActionsOrientation) {}
+}

--- a/Source/SwipeExpansionStyle.swift
+++ b/Source/SwipeExpansionStyle.swift
@@ -9,15 +9,15 @@ import UIKit
 
 /// Describes the expansion style.  Expansion is the behavior when the cell is swiped past a defined threshold.
 public struct SwipeExpansionStyle {    
-    /// The default action performs a selection-type behavior. The cell bounces back to its unopened state upon selection and the row remains in the table view.
+    /// The default action performs a selection-type behavior. The cell bounces back to its unopened state upon selection and the row remains in the table/collection view.
     public static var selection: SwipeExpansionStyle { return SwipeExpansionStyle(target: .percentage(0.5),
                                                                                   elasticOverscroll: true,
                                                                                   completionAnimation: .bounce) }
     
-    /// The default action performs a destructive behavior. The cell is removed from the table view in an animated fashion.
+    /// The default action performs a destructive behavior. The cell is removed from the table/collection view in an animated fashion.
     public static var destructive: SwipeExpansionStyle { return .destructive(automaticallyDelete: true, timing: .with) }
 
-    /// The default action performs a destructive behavior after the fill animation completes. The cell is removed from the table view in an animated fashion.
+    /// The default action performs a destructive behavior after the fill animation completes. The cell is removed from the table/collection view in an animated fashion.
     public static var destructiveAfterFill: SwipeExpansionStyle { return .destructive(automaticallyDelete: true, timing: .after) }
 
     /// The default action performs a fill behavior.
@@ -82,17 +82,19 @@ public struct SwipeExpansionStyle {
         self.completionAnimation = completionAnimation
     }
     
-    func shouldExpand(view: Swipeable, gesture: UIPanGestureRecognizer, in superview: UIView) -> Bool {
+    func shouldExpand(view: Swipeable, gesture: UIPanGestureRecognizer, in superview: UIView, usingFrame: CGRect? = nil) -> Bool {
         guard let actionsView = view.actionsView else { return false }
         
-        guard abs(view.frame.minX) >= actionsView.preferredWidth else { return false }
+        let trueXDelta = abs(usingFrame?.minX ?? view.frame.minX)
+        guard trueXDelta >= actionsView.preferredWidth else { return false }
+        if trueXDelta >= targetOffset(for: view) { return true }
         
-        if abs(view.frame.minX) >= target.offset(for: view, in: superview, minimumOverscroll: minimumTargetOverscroll) {
-            return true
-        }
-        
+        // If we've been given an override frame, we need to change which frame of reference to use in
+        //   the isTriggered method. This is useful when `view` is a cell, but the override frame
+        //   belongs to the view's content view (when the content view is moving, but not the `view`).
+        let referenceFrame: CGRect = usingFrame != nil ? view.frame : superview.bounds
         for trigger in additionalTriggers {
-            if trigger.isTriggered(view: view, gesture: gesture, in: superview) {
+            if trigger.isTriggered(view: view, gesture: gesture, in: superview, referenceFrame: referenceFrame) {
                 return true
             }
         }
@@ -100,8 +102,8 @@ public struct SwipeExpansionStyle {
         return false
     }
     
-    func targetOffset(for view: Swipeable, in superview: UIView) -> CGFloat {
-        return target.offset(for: view, in: superview, minimumOverscroll: minimumTargetOverscroll)
+    func targetOffset(for view: Swipeable) -> CGFloat {
+        return target.offset(for: view, minimumOverscroll: minimumTargetOverscroll)
     }
 }
 
@@ -114,15 +116,15 @@ extension SwipeExpansionStyle {
         /// The target is specified by a edge inset.
         case edgeInset(CGFloat)
         
-        func offset(for view: Swipeable, in superview: UIView, minimumOverscroll: CGFloat) -> CGFloat {
+        func offset(for view: Swipeable, minimumOverscroll: CGFloat) -> CGFloat {
             guard let actionsView = view.actionsView else { return .greatestFiniteMagnitude }
             
             let offset: CGFloat = {
                 switch self {
                 case .percentage(let value):
-                    return superview.bounds.width * value
+                    return view.frame.width * value
                 case .edgeInset(let value):
-                    return superview.bounds.width - value
+                    return view.frame.width - value
                 }
             }()
             
@@ -138,13 +140,13 @@ extension SwipeExpansionStyle {
         /// The trigger is specified by the distance in points past the fully exposed action view.
         case overscroll(CGFloat)
         
-        func isTriggered(view: Swipeable, gesture: UIPanGestureRecognizer, in superview: UIView) -> Bool {
+        func isTriggered(view: Swipeable, gesture: UIPanGestureRecognizer, in superview: UIView, referenceFrame: CGRect) -> Bool {
             guard let actionsView = view.actionsView else { return false }
             
             switch self {
             case .touchThreshold(let value):
-                let location = gesture.location(in: superview).x
-                let locationRatio = (actionsView.orientation == .left ? location : superview.bounds.width - location) / superview.bounds.width
+                let location = gesture.location(in: superview).x - referenceFrame.origin.x
+                let locationRatio = (actionsView.orientation == .left ? location : referenceFrame.width - location) / referenceFrame.width
                 return locationRatio > value
             case .overscroll(let value):
                 return abs(view.frame.minX) > actionsView.preferredWidth + value

--- a/Source/SwipeOptions.swift
+++ b/Source/SwipeOptions.swift
@@ -7,8 +7,8 @@
 
 import UIKit
 
-/// The `SwipeTableOptions` class provides options for transistion and expansion behavior for swiped cell.
-public struct SwipeTableOptions {
+/// The `SwipeOptions` class provides options for transistion and expansion behavior for swiped cell.
+public struct SwipeOptions {
     /// The transition style. Transition is the style of how the action buttons are exposed during the swipe.
     public var transitionStyle: SwipeTransitionStyle = .border
     
@@ -25,7 +25,7 @@ public struct SwipeTableOptions {
     
     /// The largest allowable button width.
     ///
-    /// - note: By default, the value is set to the table view divided by the number of action buttons minus some additional padding. If the value is set to 0, then word wrapping will not occur and the buttons will grow as large as needed to fit the entire title/image.
+    /// - note: By default, the value is set to the table/collection view divided by the number of action buttons minus some additional padding. If the value is set to 0, then word wrapping will not occur and the buttons will grow as large as needed to fit the entire title/image.
     public var maximumButtonWidth: CGFloat?
     
     /// The smallest allowable button width.
@@ -42,7 +42,7 @@ public struct SwipeTableOptions {
     /// The amount of space, in points, between the button image and the button title.
     public var buttonSpacing: CGFloat?
     
-    /// Constructs a new `SwipeTableOptions` instance with default options.
+    /// Constructs a new `SwipeOptions` instance with default options.
     public init() {}
 }
 
@@ -54,7 +54,7 @@ public enum SwipeTransitionStyle {
     /// The visible action area is dragged, pinned to the cell, with each action button fully sized as it is exposed.
     case drag
     
-    /// The visible action area sits behind the cell, pinned to the edge of the table view, and is revealed as the cell is dragged aside.
+    /// The visible action area sits behind the cell, pinned to the edge of the table/collection view, and is revealed as the cell is dragged aside.
     case reveal
 }
 

--- a/Source/SwipeTableViewCellDelegate.swift
+++ b/Source/SwipeTableViewCellDelegate.swift
@@ -33,11 +33,11 @@ public protocol SwipeTableViewCellDelegate: class {
      
      - parameter orientation: The side of the cell requesting this information.
      
-     - returns: A `SwipeTableOptions` instance which configures the behavior of the action buttons.
+     - returns: A `SwipeOptions` instance which configures the behavior of the action buttons.
      
-     - note: If not implemented, a default `SwipeTableOptions` instance is used.
+     - note: If not implemented, a default `SwipeOptions` instance is used.
      */
-    func tableView(_ tableView: UITableView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeTableOptions
+    func tableView(_ tableView: UITableView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions
     
     /**
      Tells the delegate that the table view is about to go into editing mode.
@@ -66,8 +66,8 @@ public protocol SwipeTableViewCellDelegate: class {
  Default implementation of `SwipeTableViewCellDelegate` methods
  */
 public extension SwipeTableViewCellDelegate {
-    func tableView(_ tableView: UITableView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeTableOptions {
-        return SwipeTableOptions()
+    func tableView(_ tableView: UITableView, editActionsOptionsForRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) -> SwipeOptions {
+        return SwipeOptions()
     }
     
     func tableView(_ tableView: UITableView, willBeginEditingRowAt indexPath: IndexPath, for orientation: SwipeActionsOrientation) {}

--- a/Source/Swipeable.swift
+++ b/Source/Swipeable.swift
@@ -18,6 +18,7 @@ protocol Swipeable {
 }
 
 extension SwipeTableViewCell: Swipeable {}
+extension SwipeCollectionViewCell: Swipeable {}
 
 enum SwipeState: Int {
     case center = 0

--- a/SwipeCellKit.xcodeproj/project.pbxproj
+++ b/SwipeCellKit.xcodeproj/project.pbxproj
@@ -18,12 +18,17 @@
 		3F3ED7121E48AF37009DD5D8 /* SwipeTableViewCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3ED7111E48AF37009DD5D8 /* SwipeTableViewCellDelegate.swift */; };
 		3F4C721D1E7E8BC20097399A /* SwipeExpansionStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C721C1E7E8BC20097399A /* SwipeExpansionStyle.swift */; };
 		3F4C721F1E7E8C180097399A /* Swipeable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F4C721E1E7E8C180097399A /* Swipeable.swift */; };
-		3F51DA071E462F9B005467BD /* SwipeTableOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F51DA061E462F9B005467BD /* SwipeTableOptions.swift */; };
 		3F6433DA1EA53AC3008B1D48 /* SwipeTableViewCell+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F6433D91EA53AC3008B1D48 /* SwipeTableViewCell+Display.swift */; };
 		3FA78CA11E5A5A0B00A1D8FF /* SwipeTableViewCell+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA78CA01E5A5A0B00A1D8FF /* SwipeTableViewCell+Accessibility.swift */; };
 		3FD016701E696D8D00B54FFC /* SwipeTransitionLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD0166F1E696D8D00B54FFC /* SwipeTransitionLayout.swift */; };
 		3FD016DF1E6D778700B54FFC /* SwipeExpanding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD016DE1E6D778700B54FFC /* SwipeExpanding.swift */; };
 		3FD016E11E6D7F7700B54FFC /* SwipeActionTransitioning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD016E01E6D7F7700B54FFC /* SwipeActionTransitioning.swift */; };
+		B93ECA8F1EDEE80700AE05AD /* SwipeCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA8E1EDEE80700AE05AD /* SwipeCollectionViewCell.swift */; };
+		B93ECA911EDEE87800AE05AD /* SwipeCollectionViewCell+Accessibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA901EDEE87800AE05AD /* SwipeCollectionViewCell+Accessibility.swift */; };
+		B93ECA931EDEE88800AE05AD /* SwipeCollectionViewCell+Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA921EDEE88800AE05AD /* SwipeCollectionViewCell+Display.swift */; };
+		B93ECA951EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA941EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift */; };
+		B93ECA991EDEE93D00AE05AD /* SwipeAccessibilityCustomAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA981EDEE93D00AE05AD /* SwipeAccessibilityCustomAction.swift */; };
+		B93ECA9B1EDEEABA00AE05AD /* SwipeOptions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ECA9A1EDEEABA00AE05AD /* SwipeOptions.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -40,12 +45,17 @@
 		3F3ED7111E48AF37009DD5D8 /* SwipeTableViewCellDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeTableViewCellDelegate.swift; sourceTree = "<group>"; };
 		3F4C721C1E7E8BC20097399A /* SwipeExpansionStyle.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeExpansionStyle.swift; sourceTree = "<group>"; };
 		3F4C721E1E7E8C180097399A /* Swipeable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Swipeable.swift; sourceTree = "<group>"; };
-		3F51DA061E462F9B005467BD /* SwipeTableOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeTableOptions.swift; sourceTree = "<group>"; };
 		3F6433D91EA53AC3008B1D48 /* SwipeTableViewCell+Display.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwipeTableViewCell+Display.swift"; sourceTree = "<group>"; };
 		3FA78CA01E5A5A0B00A1D8FF /* SwipeTableViewCell+Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwipeTableViewCell+Accessibility.swift"; sourceTree = "<group>"; };
 		3FD0166F1E696D8D00B54FFC /* SwipeTransitionLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeTransitionLayout.swift; sourceTree = "<group>"; };
 		3FD016DE1E6D778700B54FFC /* SwipeExpanding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeExpanding.swift; sourceTree = "<group>"; };
 		3FD016E01E6D7F7700B54FFC /* SwipeActionTransitioning.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeActionTransitioning.swift; sourceTree = "<group>"; };
+		B93ECA8E1EDEE80700AE05AD /* SwipeCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeCollectionViewCell.swift; sourceTree = "<group>"; };
+		B93ECA901EDEE87800AE05AD /* SwipeCollectionViewCell+Accessibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwipeCollectionViewCell+Accessibility.swift"; sourceTree = "<group>"; };
+		B93ECA921EDEE88800AE05AD /* SwipeCollectionViewCell+Display.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SwipeCollectionViewCell+Display.swift"; sourceTree = "<group>"; };
+		B93ECA941EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeCollectionViewCellDelegate.swift; sourceTree = "<group>"; };
+		B93ECA981EDEE93D00AE05AD /* SwipeAccessibilityCustomAction.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeAccessibilityCustomAction.swift; sourceTree = "<group>"; };
+		B93ECA9A1EDEEABA00AE05AD /* SwipeOptions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SwipeOptions.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -80,12 +90,17 @@
 			children = (
 				3F4C721E1E7E8C180097399A /* Swipeable.swift */,
 				170BCE711E8340C000F46E18 /* SwipeAnimator.swift */,
+				B93ECA981EDEE93D00AE05AD /* SwipeAccessibilityCustomAction.swift */,
 				3F234AD21E44A94F00E22A38 /* SwipeTableViewCell.swift */,
 				3FA78CA01E5A5A0B00A1D8FF /* SwipeTableViewCell+Accessibility.swift */,
 				3F6433D91EA53AC3008B1D48 /* SwipeTableViewCell+Display.swift */,
 				3F3ED7111E48AF37009DD5D8 /* SwipeTableViewCellDelegate.swift */,
-				3F51DA061E462F9B005467BD /* SwipeTableOptions.swift */,
+				B93ECA8E1EDEE80700AE05AD /* SwipeCollectionViewCell.swift */,
+				B93ECA901EDEE87800AE05AD /* SwipeCollectionViewCell+Accessibility.swift */,
+				B93ECA921EDEE88800AE05AD /* SwipeCollectionViewCell+Display.swift */,
+				B93ECA941EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift */,
 				3FD0166F1E696D8D00B54FFC /* SwipeTransitionLayout.swift */,
+				B93ECA9A1EDEEABA00AE05AD /* SwipeOptions.swift */,
 				3F234AD41E44A94F00E22A38 /* SwipeActionsView.swift */,
 				3F234AD31E44A94F00E22A38 /* SwipeAction.swift */,
 				3F3ED70F1E486993009DD5D8 /* SwipeActionButton.swift */,
@@ -190,16 +205,21 @@
 				3F234AD81E44A94F00E22A38 /* SwipeActionsView.swift in Sources */,
 				3F234AD71E44A94F00E22A38 /* SwipeAction.swift in Sources */,
 				3F3ED7101E486993009DD5D8 /* SwipeActionButton.swift in Sources */,
+				B93ECA931EDEE88800AE05AD /* SwipeCollectionViewCell+Display.swift in Sources */,
 				3F234AD61E44A94F00E22A38 /* SwipeTableViewCell.swift in Sources */,
 				3F19AD041E8D711C006B4B3A /* SwipeFeedback.swift in Sources */,
+				B93ECA951EDEE8A700AE05AD /* SwipeCollectionViewCellDelegate.swift in Sources */,
 				3FD016701E696D8D00B54FFC /* SwipeTransitionLayout.swift in Sources */,
 				3FA78CA11E5A5A0B00A1D8FF /* SwipeTableViewCell+Accessibility.swift in Sources */,
+				B93ECA8F1EDEE80700AE05AD /* SwipeCollectionViewCell.swift in Sources */,
 				3F4C721F1E7E8C180097399A /* Swipeable.swift in Sources */,
 				3F4C721D1E7E8BC20097399A /* SwipeExpansionStyle.swift in Sources */,
+				B93ECA911EDEE87800AE05AD /* SwipeCollectionViewCell+Accessibility.swift in Sources */,
 				3F3ED7121E48AF37009DD5D8 /* SwipeTableViewCellDelegate.swift in Sources */,
 				3FD016E11E6D7F7700B54FFC /* SwipeActionTransitioning.swift in Sources */,
+				B93ECA9B1EDEEABA00AE05AD /* SwipeOptions.swift in Sources */,
+				B93ECA991EDEE93D00AE05AD /* SwipeAccessibilityCustomAction.swift in Sources */,
 				3FD016DF1E6D778700B54FFC /* SwipeExpanding.swift in Sources */,
-				3F51DA071E462F9B005467BD /* SwipeTableOptions.swift in Sources */,
 				170BCE721E8340C000F46E18 /* SwipeAnimator.swift in Sources */,
 				3F6433DA1EA53AC3008B1D48 /* SwipeTableViewCell+Display.swift in Sources */,
 				3F234AD91E44A94F00E22A38 /* Extensions.swift in Sources */,


### PR DESCRIPTION
This pull request supersedes #45.

This is possible in large part thanks to @gcox and @mschonvogel for the initial implementation. This makes a copy of SwipeTableViewCell and bases it on UICollectionViewCell, making plenty of necessary adjustments to calculate translations and frames/centers based on the collection view cell's `contentView` instead of just the cell itself (like the table view cell implementation does). This means we can drag the cell left and right without it overlapping neighbor cells (clipsToBounds is true). Additionally, trigger points for the expansion animations are calculated based on the cell's position within the collection view, and not the whole collection view width like table views are.

As @gcox mentioned in his [original pull request](https://github.com/SwipeCellKit/SwipeCellKit/pull/45), `SwipeTableOptions` has been renamed to `SwipeOptions` since it's not specific to tables in any way. There's also still a fair amount of duplicated code between the two implementations, and it may be worth it to refactor this to reduce that where it makes sense.

Additionally, the example app has been updated with a `UICollectionView` example that uses a `UICollectionViewFlowLayout` set so that cells sit side by side in a 2-wide grid.

![screencast](https://user-images.githubusercontent.com/58783/35296716-8d3afff2-0042-11e8-8844-ef03d18d4c93.gif)
