### PR TITLE
Title bounding rect calculation with adjusted font sizes

### DIFF
--- a/Source/Extensions.swift
+++ b/Source/Extensions.swift
@@ -37,3 +37,29 @@ extension UIPanGestureRecognizer {
         return CGPoint(x: x, y: y)
     }
 }
+
+extension UILabel {
+    var adjustedFontSize: CGFloat {
+        get {
+            guard let text = text as NSString? else { return font.pointSize }
+            var currentFont: UIFont = font
+            let originalFontSize = currentFont.pointSize
+            var currentSize: CGSize = text.size(withAttributes: [NSAttributedStringKey.font: currentFont])
+            
+            while currentSize.width > frame.size.width && currentFont.pointSize > (originalFontSize * minimumScaleFactor) {
+                currentFont = currentFont.withSize(currentFont.pointSize - 1)
+                currentSize = text.size(withAttributes: [NSAttributedStringKey.font: currentFont])
+            }
+            
+            return currentFont.pointSize
+        }
+    }
+}
+
+extension CGRect {
+    func center(size: CGSize) -> CGRect {
+        let dx = width - size.width
+        let dy = height - size.height
+        return CGRect(x: origin.x + dx * 0.5, y: origin.y + dy * 0.5, width: size.width, height: size.height)
+    }
+}

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -9,11 +9,11 @@ import UIKit
 
 public class SwipeActionButton: UIButton {
     public var spacing: CGFloat = 8
-    public var shouldHighlight = true
-    public var highlightedBackgroundColor: UIColor?
+    var shouldHighlight = true
+    var highlightedBackgroundColor: UIColor?
 
-    public var maximumImageHeight: CGFloat = 0
-    public var verticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
+    var maximumImageHeight: CGFloat = 0
+    var verticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
     
     var currentSpacing: CGFloat {
         return (currentTitle?.isEmpty == false && maximumImageHeight > 0) ? spacing : 0

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SwipeActionButton: UIButton {
+public class SwipeActionButton: UIButton {
     var spacing: CGFloat = 8
     var shouldHighlight = true
     var highlightedBackgroundColor: UIColor?
@@ -50,7 +50,7 @@ class SwipeActionButton: UIButton {
         setImage(action.highlightedImage ?? action.image, for: .highlighted)
     }
     
-    override var isHighlighted: Bool {
+    override public var isHighlighted: Bool {
         didSet {
             guard shouldHighlight else { return }
             
@@ -78,13 +78,13 @@ class SwipeActionButton: UIButton {
                                   context: nil).integral
     }
     
-    override func titleRect(forContentRect contentRect: CGRect) -> CGRect {
+    override public func titleRect(forContentRect contentRect: CGRect) -> CGRect {
         var rect = contentRect.center(size: titleBoundingRect(with: contentRect.size).size)
         rect.origin.y = alignmentRect.minY + maximumImageHeight + currentSpacing
         return rect.integral
     }
     
-    override func imageRect(forContentRect contentRect: CGRect) -> CGRect {
+    override public func imageRect(forContentRect contentRect: CGRect) -> CGRect {
         var rect = contentRect.center(size: currentImage?.size ?? .zero)
         rect.origin.y = alignmentRect.minY + (maximumImageHeight - rect.height) / 2
         return rect

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -67,8 +67,11 @@ class SwipeActionButton: UIButton {
     }
     
     func titleBoundingRect(with size: CGSize) -> CGRect {
-        guard let title = currentTitle, let font = titleLabel?.font else { return .zero }
-        
+        guard let title = currentTitle, let label = titleLabel, var font = label.font else { return .zero }
+        if label.adjustsFontSizeToFitWidth, let adjustedFont = UIFont.init(name: font.fontName, size: label.adjustedFontSize) {
+            font = adjustedFont
+        }
+
         return title.boundingRect(with: size,
                                   options: [.usesLineFragmentOrigin],
                                   attributes: [NSAttributedStringKey.font: font],
@@ -85,13 +88,5 @@ class SwipeActionButton: UIButton {
         var rect = contentRect.center(size: currentImage?.size ?? .zero)
         rect.origin.y = alignmentRect.minY + (maximumImageHeight - rect.height) / 2
         return rect
-    }
-}
-
-extension CGRect {
-    func center(size: CGSize) -> CGRect {
-        let dx = width - size.width
-        let dy = height - size.height
-        return CGRect(x: origin.x + dx * 0.5, y: origin.y + dy * 0.5, width: size.width, height: size.height)
     }
 }

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -8,12 +8,12 @@
 import UIKit
 
 public class SwipeActionButton: UIButton {
-    var spacing: CGFloat = 8
-    var shouldHighlight = true
-    var highlightedBackgroundColor: UIColor?
+    public var spacing: CGFloat = 8
+    public var shouldHighlight = true
+    public var highlightedBackgroundColor: UIColor?
 
-    var maximumImageHeight: CGFloat = 0
-    var verticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
+    public var maximumImageHeight: CGFloat = 0
+    public var verticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
     
     var currentSpacing: CGFloat {
         return (currentTitle?.isEmpty == false && maximumImageHeight > 0) ? spacing : 0


### PR DESCRIPTION
The title bounding rect calculation of the SwipeActionButton is not taking a possible adjusted font size into account, which can be achieved with the transitionDelegate and changing button labels' properties.
The height of the button's title label is based on the original font size, therefore the calculated height might be to big if the label scaled down its font based on the adjustsFontSizeToFitWidth and minimumScaleFactor properties. The UILabel extension function adjustedFontSize (based on https://stackoverflow.com/a/32567240/390542) will return the scaled font size. titleBoundingRect function now correctly calculates the bounding rect for these cases.