### PR TITLE
UIAccessibilityCustomAction should not cause a crash when no identifier is set

### DIFF
--- a/Source/SwipeTableViewCell+Accessibility.swift
+++ b/Source/SwipeTableViewCell+Accessibility.swift
@@ -84,13 +84,13 @@ class SwipeAccessibilityCustomAction: UIAccessibilityCustomAction {
     let indexPath: IndexPath
     
     init(action: SwipeAction, indexPath: IndexPath, target: Any, selector: Selector) {
-        guard let name = action.accessibilityLabel ?? action.title ?? action.image?.accessibilityIdentifier else {
-            fatalError("You must provide either a title or an image for a SwipeAction")
-        }
-        
         self.action = action
         self.indexPath = indexPath
         
-        super.init(name: name, target: target, selector: selector)
+        if let name = action.accessibilityLabel ?? action.title ?? action.image?.accessibilityIdentifier {
+            super.init(name: name, target: target, selector: selector)
+        } else {
+            super.init(name: "", target: target, selector: selector)
+        }
     }
 }


### PR DESCRIPTION
We've been crashing when certain accessibility features were turned on and no AccessibilityIdentifiers for either the Action or image were set.

While I understand that it is best practice to set those identifiers, I think SwipeCellKit shouldn't cause a crash, especially not with a crash message that says that the action either needs to have a title or an image, yet, still crashes when an image is set but no title. (The real check that caused the crash was checking accessibilityIdentifiers of either the title or the image that didn't necessarily have to be set if either or were available)

Ideally the image should have a accessibilityIdentifier that matches the file name at worst case but unfortunately that's not how iOS does it - therefore I've set the name to an empty string if all things fail.