### PR TITLE
Change outer pinning of actionsView to support UITableViews with margins

### DIFF
--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -244,13 +244,14 @@ open class SwipeTableViewCell: UITableViewCell {
         addSubview(actionsView)
 
         actionsView.heightAnchor.constraint(equalTo: heightAnchor).isActive = true
-        actionsView.widthAnchor.constraint(equalTo: widthAnchor, multiplier: 2).isActive = true
         actionsView.topAnchor.constraint(equalTo: topAnchor).isActive = true
         
         if orientation == .left {
             actionsView.rightAnchor.constraint(equalTo: leftAnchor).isActive = true
+            actionsView.leftAnchor.constraint(equalTo: tableView.leftAnchor).isActive = true
         } else {
             actionsView.leftAnchor.constraint(equalTo: rightAnchor).isActive = true
+            actionsView.rightAnchor.constraint(equalTo: tableView.rightAnchor).isActive = true
         }
 		
 		actionsView.setNeedsUpdateConstraints()


### PR DESCRIPTION
I have an iPad app layout with a split view. 
The tableView on the right part contains a top section with full width and a little grey shaded background.
The lower section has cells that should have left-margin to separate from the left view.

Also my cells have a colored rectangle on the left, which is added by me. 
This is not part of the pull request!

I achieved this by adding left-margin to the whole table view and adding negative frame insets to the cells on the top section (while deactivating clips-to-bounds on the tableView itself).

This leads to this situation:

![ezgif-3-e8fce46e5c](https://user-images.githubusercontent.com/11268968/38098928-8e021e42-3379-11e8-994d-3592a6b977f6.gif)

Which i fixed by my code change.

![ezgif-3-25879d25f0](https://user-images.githubusercontent.com/11268968/38098939-961dae2a-3379-11e8-88d9-647cb78dda73.gif)
