### PR TITLE
v2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 `SwipeCellKit` adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.2.0](https://github.com/jerkoch/SwipeCellKit/releases/tag/2.2.0)
+
+#### Added
+
+- Swift 4.1 Support. (#181)
+- Allow mix use of only image or text label actions. (#139)
+- Cancel pan gesture (swipe) when no actions exist for that swipe orientation. (#163, #172)
+
+#### Fixed
+
+- Fix issue where multiple `SwipeTableViewCells` can be swipped simultaneously. (#57)
+- Fix issue where selected state is lost when swipping cell. (#58)
+
+---
+
 ## [2.1.0](https://github.com/jerkoch/SwipeCellKit/releases/tag/2.1.0)
 
 #### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@
 
 - Swift 4.1 Support. (#181)
 - Allow mix use of only image or text label actions. (#139)
-- Cancel pan gesture (swipe) when no actions exist for that swipe orientation. (#163, #172)
 
 #### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 #### Fixed
 
 - Fix issue where multiple `SwipeTableViewCells` can be swipped simultaneously. (#57)
-- Fix issue where selected state is lost when swipping cell. (#58)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/jerkoch/SwipeCellKit.svg)](https://travis-ci.org/jerkoch/SwipeCellKit) 
 [![Version Status](https://img.shields.io/cocoapods/v/SwipeCellKit.svg)][podLink] 
-[![Swift 4.0](https://img.shields.io/badge/Swift-4.0-orange.svg?style=flat)](https://developer.apple.com/swift/)
+[![Swift 4.1](https://img.shields.io/badge/Swift-4.1-orange.svg?style=flat)](https://developer.apple.com/swift/)
 [![license MIT](https://img.shields.io/cocoapods/l/SwipeCellKit.svg)][mitLink] 
 [![Platform](https://img.shields.io/cocoapods/p/SwipeCellKit.svg)][docsLink] 
 [![Carthage compatible](https://img.shields.io/badge/Carthage-compatible-4BC51D.svg?style=flat)](https://github.com/Carthage/Carthage)

--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ The expansion style describes the behavior when the cell is swiped past a define
 
 ## Requirements
 
-* Swift 4.0
-* Xcode 9
+* Swift 4.1
+* Xcode 9+
 * iOS 9.0+
 
 ## Installation

--- a/Source/Extensions.swift
+++ b/Source/Extensions.swift
@@ -9,7 +9,7 @@ import UIKit
 
 extension UITableView {
     var swipeCells: [SwipeTableViewCell] {
-        return visibleCells.flatMap({ $0 as? SwipeTableViewCell })
+        return visibleCells.compactMap({ $0 as? SwipeTableViewCell })
     }
     
     func hideSwipeCell() {

--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.0</string>
+	<string>2.2.0</string>
 	<key>CFBundleVersion</key>
 	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSPrincipalClass</key>

--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -15,16 +15,23 @@ class SwipeActionButton: UIButton {
     var maximumImageHeight: CGFloat = 0
     var verticalAlignment: SwipeVerticalAlignment = .centerFirstBaseline
     
+    
     var currentSpacing: CGFloat {
-        return (currentTitle?.isEmpty == false && maximumImageHeight > 0) ? spacing : 0
+        return (currentTitle?.isEmpty == false && imageHeight > 0) ? spacing : 0
     }
     
     var alignmentRect: CGRect {
         let contentRect = self.contentRect(forBounds: bounds)
         let titleHeight = titleBoundingRect(with: verticalAlignment == .centerFirstBaseline ? CGRect.infinite.size : contentRect.size).integral.height
-        let totalHeight = maximumImageHeight + titleHeight + currentSpacing
+        let totalHeight = imageHeight + titleHeight + currentSpacing
 
         return contentRect.center(size: CGSize(width: contentRect.width, height: totalHeight))
+    }
+    
+    private var imageHeight: CGFloat {
+        get {
+            return currentImage == nil ? 0 : maximumImageHeight
+        }
     }
     
     convenience init(action: SwipeAction) {
@@ -77,13 +84,13 @@ class SwipeActionButton: UIButton {
     
     override func titleRect(forContentRect contentRect: CGRect) -> CGRect {
         var rect = contentRect.center(size: titleBoundingRect(with: contentRect.size).size)
-        rect.origin.y = alignmentRect.minY + maximumImageHeight + currentSpacing
+        rect.origin.y = alignmentRect.minY + imageHeight + currentSpacing
         return rect.integral
     }
     
     override func imageRect(forContentRect contentRect: CGRect) -> CGRect {
         var rect = contentRect.center(size: currentImage?.size ?? .zero)
-        rect.origin.y = alignmentRect.minY + (maximumImageHeight - rect.height) / 2
+        rect.origin.y = alignmentRect.minY + (imageHeight - rect.height) / 2
         return rect
     }
 }

--- a/Source/SwipeTableViewCell+Accessibility.swift
+++ b/Source/SwipeTableViewCell+Accessibility.swift
@@ -47,7 +47,7 @@ extension SwipeTableViewCell {
             let leftActions = delegate?.tableView(tableView, editActionsForRowAt: indexPath, for: .left) ?? []
             let rightActions = delegate?.tableView(tableView, editActionsForRowAt: indexPath, for: .right) ?? []
             
-            let actions = [rightActions.first, leftActions.first].flatMap({ $0 }) + rightActions.dropFirst() + leftActions.dropFirst()
+            let actions = [rightActions.first, leftActions.first].compactMap({ $0 }) + rightActions.dropFirst() + leftActions.dropFirst()
             
             if actions.count > 0 {
                 return actions.map({ SwipeAccessibilityCustomAction(action: $0,

--- a/Source/SwipeTableViewCell+Display.swift
+++ b/Source/SwipeTableViewCell+Display.swift
@@ -30,13 +30,11 @@ extension SwipeTableViewCell {
         
         if animated {
             animate(toOffset: targetCenter) { complete in
-                self.selectedIndexPaths?.forEach { self.tableView?.selectRow(at: $0, animated: false, scrollPosition: .none) }
                 self.reset()
                 completion?(complete)
             }
         } else {
             center = CGPoint(x: targetCenter, y: self.center.y)
-            self.selectedIndexPaths?.forEach { self.tableView?.selectRow(at: $0, animated: false, scrollPosition: .none) }
             reset()
         }
         

--- a/Source/SwipeTableViewCell+Display.swift
+++ b/Source/SwipeTableViewCell+Display.swift
@@ -30,11 +30,13 @@ extension SwipeTableViewCell {
         
         if animated {
             animate(toOffset: targetCenter) { complete in
+                self.selectedIndexPaths?.forEach { self.tableView?.selectRow(at: $0, animated: false, scrollPosition: .none) }
                 self.reset()
                 completion?(complete)
             }
         } else {
             center = CGPoint(x: targetCenter, y: self.center.y)
+            self.selectedIndexPaths?.forEach { self.tableView?.selectRow(at: $0, animated: false, scrollPosition: .none) }
             reset()
         }
         

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -24,8 +24,6 @@ open class SwipeTableViewCell: UITableViewCell {
     
     weak var tableView: UITableView?
     var actionsView: SwipeActionsView?
-    
-    var selectedIndexPaths: [IndexPath]?
 
     var originalLayoutMargins: UIEdgeInsets = .zero
     
@@ -229,8 +227,8 @@ open class SwipeTableViewCell: UITableViewCell {
         
         // Remove highlight and deselect any selected cells
         super.setHighlighted(false, animated: false)
-        self.selectedIndexPaths = tableView.indexPathsForSelectedRows
-        self.selectedIndexPaths?.forEach { tableView.deselectRow(at: $0, animated: false) }
+        let selectedIndexPaths = tableView.indexPathsForSelectedRows
+        selectedIndexPaths?.forEach { tableView.deselectRow(at: $0, animated: false) }
         
         configureActionsView(with: actions, for: orientation)
         
@@ -408,8 +406,6 @@ extension SwipeTableViewCell {
         clipsToBounds = false
         actionsView?.removeFromSuperview()
         actionsView = nil
-        selectedIndexPaths?.forEach { tableView?.selectRow(at: $0, animated: false, scrollPosition: .none) }
-        selectedIndexPaths = nil
     }
 }
 
@@ -462,14 +458,6 @@ extension SwipeTableViewCell: SwipeActionsViewDelegate {
             case .delete:
                 self?.mask = actionsView.createDeletionMask()
                 
-                // Remove deleted row from selectedIndexPaths & adjust selected index paths that are below deleted cell
-                self?.selectedIndexPaths = self?.selectedIndexPaths?.compactMap({
-                    guard $0 != indexPath else { return nil }
-                    if $0.section == indexPath.section && $0.row > indexPath.row {
-                        return IndexPath(row: $0.row - 1, section: $0.section)
-                    }
-                    return $0
-                })
                 tableView.deleteRows(at: [indexPath], with: .none)
                 
                 UIView.animate(withDuration: 0.3, animations: {

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -118,13 +118,13 @@ open class SwipeTableViewCell: UITableViewCell {
         guard isEditing == false else { return }
         guard let target = gesture.view else { return }
         
+        let cell = tableView?.swipeCells.first(where: { $0.state.isActive })
+        if (cell != nil && cell != target) {
+            return;
+        }
+        
         switch gesture.state {
         case .began:
-            let cell = tableView?.swipeCells.first(where: { $0.state.isActive })
-            if (cell != nil && cell != target) {
-                return;
-            }
-            
             stopAnimatorIfNeeded()
 
             originalCenter = center.x

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -118,9 +118,8 @@ open class SwipeTableViewCell: UITableViewCell {
         guard isEditing == false else { return }
         guard let target = gesture.view else { return }
         
-        let cell = tableView?.swipeCells.first(where: { $0.state.isActive })
-        if (cell != nil && cell != target) {
-            return;
+        if let cell = tableView?.swipeCells.first(where: { $0.state.isActive }), cell != target {
+            return
         }
         
         switch gesture.state {
@@ -360,11 +359,7 @@ open class SwipeTableViewCell: UITableViewCell {
     
     /// :nodoc:
     override open func setHighlighted(_ highlighted: Bool, animated: Bool) {
-        let noSwipeCellPanning = tableView?.swipeCells.first(where: {
-            $0.panGestureRecognizer.state.rawValue >= UIGestureRecognizerState.began.rawValue
-        }) == nil
-        
-        if noSwipeCellPanning && state == .center {
+        if state == .center {
             super.setHighlighted(highlighted, animated: animated)
         }
     }
@@ -501,21 +496,15 @@ extension SwipeTableViewCell {
             if UIAccessibilityIsVoiceOverRunning() {
                 tableView?.hideSwipeCell()
             }
-
-            let noSwipeCellPanning = tableView?.swipeCells.first(where: {
-                $0.panGestureRecognizer.state.rawValue >= UIGestureRecognizerState.began.rawValue
-            }) == nil
             
-            if noSwipeCellPanning == false {
-                return true
-            }
-            
-            let cell = tableView?.swipeCells.first(where: { $0.state.isActive })
-            return cell == nil ? false : true
+            let swipedCell = tableView?.swipeCells.first(where: {
+                $0.state.isActive || $0.panGestureRecognizer.state.rawValue >= UIGestureRecognizerState.began.rawValue
+            })
+            return swipedCell == nil ? false : true
         }
         
         if gestureRecognizer == panGestureRecognizer,
-            let view = gestureRecognizer.view as? SwipeTableViewCell,
+            let view = gestureRecognizer.view,
             let gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer
         {
             let translation = gestureRecognizer.translation(in: view)

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -132,11 +132,7 @@ open class SwipeTableViewCell: UITableViewCell {
                 let velocity = gesture.velocity(in: target)
                 let orientation: SwipeActionsOrientation = velocity.x > 0 ? .left : .right
 
-                if showActionsView(for: orientation) == false {
-                    // Cancel Pan Gesture when no actions exist for orientation
-                    gesture.isEnabled = false
-                    gesture.isEnabled = true
-                }
+                showActionsView(for: orientation)
             }
             
         case .changed:

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -135,7 +135,11 @@ open class SwipeTableViewCell: UITableViewCell {
                 let velocity = gesture.velocity(in: target)
                 let orientation: SwipeActionsOrientation = velocity.x > 0 ? .left : .right
 
-                showActionsView(for: orientation)
+                if showActionsView(for: orientation) == false {
+                    // Cancel Pan Gesture when no actions exist for orientation
+                    gesture.isEnabled = false
+                    gesture.isEnabled = true
+                }
             }
             
         case .changed:

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -118,12 +118,13 @@ open class SwipeTableViewCell: UITableViewCell {
         guard isEditing == false else { return }
         guard let target = gesture.view else { return }
         
-        if let cell = tableView?.swipeCells.first(where: { $0.state.isActive }), cell != target {
-            return
-        }
-        
         switch gesture.state {
         case .began:
+            
+            if let cell = tableView?.swipeCells.first(where: { $0.state.isActive }), cell != target {
+                return
+            }
+            
             stopAnimatorIfNeeded()
 
             originalCenter = center.x
@@ -137,7 +138,11 @@ open class SwipeTableViewCell: UITableViewCell {
             
         case .changed:
             guard let actionsView = actionsView else { return }
-
+            
+            if state.isActive == false {
+                return
+            }
+            
             let translation = gesture.translation(in: target).x
             scrollRatio = 1.0
             
@@ -182,6 +187,10 @@ open class SwipeTableViewCell: UITableViewCell {
         case .ended:
             guard let actionsView = actionsView else { return }
 
+            if state.isActive == false {
+                return
+            }
+            
             let velocity = gesture.velocity(in: target)
             state = targetState(forVelocity: velocity)
             

--- a/SwipeCellKit.podspec
+++ b/SwipeCellKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
    s.name = 'SwipeCellKit'
-   s.version = '2.1.0'
+   s.version = '2.2.0'
    s.license = 'MIT'
 
    s.summary = 'Swipeable UITableViewCell based on the stock Mail.app, implemented in Swift.'

--- a/SwipeCellKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/SwipeCellKit.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
#### Added

- Swift 4.1 Support. (#181)
- Allow mix use of only image or text label actions. (#139)
- Cancel pan gesture (swipe) when no actions exist for that swipe orientation. (#163, #172)

#### Fixed

- Fix issue where multiple `SwipeTableViewCells` can be swipped simultaneously. (#57)
- Fix issue where selected state is lost when swipping cell. (#58)