### PR TITLE
Fix "Ambiguous use of 'frame'" compiler errors in Xcode 10

### DIFF
--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -99,7 +99,8 @@ class SwipeController: NSObject {
                 target.center.x = gesture.elasticTranslation(in: target,
                                                              withLimit: .zero,
                                                              fromOriginalCenter: CGPoint(x: originalCenter, y: 0)).x
-                swipeable.actionsView?.visibleWidth = abs(swipeable.frame.minX)
+                let swipeableFrame = (swipeable as Swipeable).frame
+                swipeable.actionsView?.visibleWidth = abs(swipeableFrame.minX)
                 scrollRatio = elasticScrollRatio
                 return
             }
@@ -192,10 +193,11 @@ class SwipeController: NSObject {
         
         var contentEdgeInsets = UIEdgeInsets.zero
         if let visibleTableViewRect = delegate?.swipeController(self, visibleRectFor: scrollView) {
-            let visibleSwipeableRect = swipeable.frame.intersection(visibleTableViewRect)
+            let swipeableFrame = (swipeable as Swipeable).frame
+            let visibleSwipeableRect = swipeableFrame.intersection(visibleTableViewRect)
             if visibleSwipeableRect.isNull == false {
-                let top = visibleSwipeableRect.minY > swipeable.frame.minY ? max(0, visibleSwipeableRect.minY - swipeable.frame.minY) : 0
-                let bottom = max(0, swipeable.frame.size.height - visibleSwipeableRect.size.height - top)
+                let top = visibleSwipeableRect.minY > swipeableFrame.minY ? max(0, visibleSwipeableRect.minY - swipeableFrame.minY) : 0
+                let bottom = max(0, swipeableFrame.size.height - visibleSwipeableRect.size.height - top)
                 contentEdgeInsets = UIEdgeInsets(top: top, left: 0, bottom: bottom, right: 0)
             }
         }


### PR DESCRIPTION
This seems to be due to `weak var swipeable: (UIView & Swipeable)?`, as both `UIView` and `Swipeable` have a `frame` property.

Besides that, everything else looks to be working 😄