### PR TITLE
Add SwipeDirection option set that allows to define which swipe directions are allowed on a specific cell

### DIFF
--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -18,6 +18,9 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     /// The object that acts as the delegate of the `SwipeCollectionViewCell`.
     public weak var delegate: SwipeCollectionViewCellDelegate?
     
+    /// Defines which swipe direction is allowed for the cell
+    open var direction: SwipeDirection = [.LeftToRight, .RightToLeft]
+    
     var state = SwipeState.center
     var actionsView: SwipeActionsView?
     var scrollView: UIScrollView? {

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -359,7 +359,16 @@ extension SwipeController: UIGestureRecognizerDelegate {
             let view = gestureRecognizer.view,
             let gestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer {
             let translation = gestureRecognizer.translation(in: view)
-            return abs(translation.y) <= abs(translation.x)
+            if abs(translation.y) <= abs(translation.x) {
+                guard let swipeable = self.swipeable else { return false }
+                
+                return swipeable.state.isActive ||
+                    (translation.x < 0 && swipeable.direction.contains(.RightToLeft)) ||
+                    (translation.x > 0 && swipeable.direction.contains(.LeftToRight))
+            }
+            else {
+                return false
+            }
         }
         
         return true

--- a/Source/SwipeTableViewCell.swift
+++ b/Source/SwipeTableViewCell.swift
@@ -18,6 +18,9 @@ open class SwipeTableViewCell: UITableViewCell {
     /// The object that acts as the delegate of the `SwipeTableViewCell`.
     public weak var delegate: SwipeTableViewCellDelegate?
     
+    /// Defines which swipe direction is allowed for the cell
+    open var direction: SwipeDirection = [.LeftToRight, .RightToLeft]
+    
     var state = SwipeState.center
     var actionsView: SwipeActionsView?
     var scrollView: UIScrollView? {

--- a/Source/Swipeable.swift
+++ b/Source/Swipeable.swift
@@ -10,6 +10,8 @@ import UIKit
 // MARK: - Internal 
 
 protocol Swipeable {
+    var direction: SwipeDirection { get set }
+    
     var state: SwipeState { get set }
     
     var actionsView: SwipeActionsView? { get set }
@@ -38,4 +40,33 @@ enum SwipeState: Int {
     }
     
     var isActive: Bool { return self != .center }
+}
+
+/// Describes which swipe direction is allowed for the cell
+public struct SwipeDirection: OptionSet {
+    
+    private enum Options: Int {
+        case none
+        case rightToLeft
+        case leftToRight
+    }
+    
+    public let rawValue: Int
+    
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+    
+    private init(_ options: Options) {
+        self.rawValue = options.rawValue
+    }
+    
+    /// Swipe is not allowed at all on the cell
+    public static let None = SwipeDirection(.none)
+    
+    /// Allows user to swipe the cell from the right to the left
+    public static let RightToLeft = SwipeDirection(.rightToLeft)
+    
+    /// Allows user to swipe the cell from the left to the right
+    public static let LeftToRight = SwipeDirection(.leftToRight)
 }


### PR DESCRIPTION
Hi,

I've added a new property (direction) in the Swipeable protocol that allows to define on each cell the allowed directions for the swipe (none, right to left, left to right or both).

I though you might be interested into merging it.
Cheers,
Julien