### PR TITLE
Fix crash when passing empty String to UIAccessibilityCustomAction

### DIFF
--- a/Source/SwipeAccessibilityCustomAction.swift
+++ b/Source/SwipeAccessibilityCustomAction.swift
@@ -12,13 +12,17 @@ class SwipeAccessibilityCustomAction: UIAccessibilityCustomAction {
     let action: SwipeAction
     let indexPath: IndexPath
     
-    init(action: SwipeAction, indexPath: IndexPath, target: Any, selector: Selector) {
+    init?(action: SwipeAction, indexPath: IndexPath, target: Any, selector: Selector) {
         
         self.action = action
         self.indexPath = indexPath
         
-        let name = action.accessibilityLabel ?? action.title ?? action.image?.accessibilityIdentifier ?? ""
+        let name = action.accessibilityLabel ?? action.title ?? action.image?.accessibilityIdentifier ?? nil
         
-        super.init(name: name, target: target, selector: selector)
+        if let name = name {
+            super.init(name: name, target: target, selector: selector)
+        } else {
+            return nil
+        }
     }
 }

--- a/Source/SwipeCollectionViewCell+Accessibility.swift
+++ b/Source/SwipeCollectionViewCell+Accessibility.swift
@@ -50,7 +50,7 @@ extension SwipeCollectionViewCell {
             let actions = [rightActions.first, leftActions.first].compactMap({ $0 }) + rightActions.dropFirst() + leftActions.dropFirst()
             
             if actions.count > 0 {
-                return actions.map({ SwipeAccessibilityCustomAction(action: $0,
+                return actions.compactMap({ SwipeAccessibilityCustomAction(action: $0,
                                                                     indexPath: indexPath,
                                                                     target: self,
                                                                     selector: #selector(performAccessibilityCustomAction(accessibilityCustomAction:))) })

--- a/Source/SwipeTableViewCell+Accessibility.swift
+++ b/Source/SwipeTableViewCell+Accessibility.swift
@@ -50,7 +50,7 @@ extension SwipeTableViewCell {
             let actions = [rightActions.first, leftActions.first].compactMap({ $0 }) + rightActions.dropFirst() + leftActions.dropFirst()
             
             if actions.count > 0 {
-                return actions.map({ SwipeAccessibilityCustomAction(action: $0,
+                return actions.compactMap({ SwipeAccessibilityCustomAction(action: $0,
                                                                     indexPath: indexPath,
                                                                     target: self,
                                                                     selector: #selector(performAccessibilityCustomAction(accessibilityCustomAction:))) })


### PR DESCRIPTION
Hi @kurabi,

Creating a failable initializer for `SwipeAccessibilityCustomAction` will avoid an `NSInternalConsistency` exception that occurs when passing an empty `String` to `UIAccessibilityCustomAction`.

Thank you for the great library 🙇 