### PR TITLE
Xcode 10.2 (beta) compatibility

### DIFF
--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import UIKit
 
 protocol SwipeControllerDelegate: class {
     

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -73,7 +73,7 @@ class SwipeController: NSObject {
         
         switch gesture.state {
         case .began:
-            if let swipeable = scrollView?.swipeables.first(where: { $0.state == .dragging }) as? UIView, swipeable != self.swipeable {
+            if let swipeable = scrollView?.swipeables.first(where: { $0.state == .dragging }) as? UIView, self.swipeable != nil, swipeable != self.swipeable! {
                 return
             }
             
@@ -92,7 +92,7 @@ class SwipeController: NSObject {
             
             if swipeable.state == .animatingToCenter {
                 let swipedCell = scrollView?.swipeables.first(where: { $0.state == .dragging || $0.state == .left || $0.state == .right }) as? UIView
-                if let swipedCell = swipedCell, swipedCell != self.swipeable {
+                if let swipedCell = swipedCell, self.swipeable != nil, swipedCell != self.swipeable! {
                     return
                 }
             }


### PR DESCRIPTION
Fixes multiple build errors with Xcode 10.2 (beta) using Swift 4.2

https://github.com/SwipeCellKit/SwipeCellKit/issues/278

More precisely:
* Adds a missing import.
* Unwraps two optionals before comparison.