### PR TITLE
Replace import Foundation with UIKit for Xcode 10.2

### DIFF
--- a/Source/SwipeAnimator.swift
+++ b/Source/SwipeAnimator.swift
@@ -5,7 +5,7 @@
 //  Copyright © 2017 Jeremy Koch. All rights reserved.
 //
 
-import Foundation
+import UIKit
 
 protocol SwipeAnimator {
     /// A Boolean value indicating whether the animation is currently running.


### PR DESCRIPTION
Use UIKit as UIView.animate method is called, to allow compilation on latest Xcode 10.2 Betas (2 and 3)