### PR TITLE
Remove MailExample target from archived targets

### DIFF
--- a/SwipeCellKit.xcodeproj/xcshareddata/xcschemes/SwipeCellKit.xcscheme
+++ b/SwipeCellKit.xcodeproj/xcshareddata/xcschemes/SwipeCellKit.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:SwipeCellKit.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "NO"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "3F234AE21E44AA5E00E22A38"
+               BuildableName = "MailExample.app"
+               BlueprintName = "MailExample"
+               ReferencedContainer = "container:Example/MailExample.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction


### PR DESCRIPTION
This PR removes `MailExample` target from archived targets of the `SwipeCellKit` scheme. This change fixes #297 .

<img width="897" alt="Screen Shot 2019-03-27 at 11 44 46" src="https://user-images.githubusercontent.com/6388510/55072381-3b796b00-508b-11e9-92c0-23e6d0eabed6.png">

<img width="900" alt="Screen Shot 2019-03-27 at 12 23 37" src="https://user-images.githubusercontent.com/6388510/55072404-4e8c3b00-508b-11e9-9796-5f9120d1fb4e.png">
