### PR TITLE
Fix build under Swift 5/Xcode 10.2: UIViewNoIntrinsicMetric

### DIFF
--- a/Source/SwipeActionButton.swift
+++ b/Source/SwipeActionButton.swift
@@ -35,7 +35,7 @@ class SwipeActionButton: UIButton {
     }
     
     override var intrinsicContentSize: CGSize {
-        return CGSize(width: UIView.noIntrinsicMetric, height: contentEdgeInsets.top + alignmentRect.height + contentEdgeInsets.bottom)
+        return CGSize(width: UIViewNoIntrinsicMetric, height: contentEdgeInsets.top + alignmentRect.height + contentEdgeInsets.bottom)
     }
     
     convenience init(action: SwipeAction) {


### PR DESCRIPTION
Seems like this project was updated to Swift 5, but I wasn't able to build without this additional change.