### PR TITLE
Don’t use custom hitTest if the cell is hidden

### DIFF
--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -153,7 +153,11 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     //   the collection view.
     /// :nodoc:
     open override func hitTest(_ point: CGPoint, with event: UIEvent?) -> UIView? {
-        guard let actionsView = actionsView else { return super.hitTest(point, with: event) }
+        guard
+          let actionsView = actionsView,
+          isHidden == false
+        else { return super.hitTest(point, with: event) }
+
         let modifiedPoint = actionsView.convert(point, from: self)
         return actionsView.hitTest(modifiedPoint, with: event) ?? super.hitTest(point, with: event)
     }


### PR DESCRIPTION
### This PR fixes the following edge case:

When a cell is deleted using `collectionView.deleteItems`, `UICollectionView` just sets the `isHidden` flag of the cell to `false` but the cell view stays "physically" at the same location.

If the `actionsContainerView` of the cell was visible before the deletion, this cell still accepts touches because of the custom `hitTest` implementation. This prevents the new cell, which moved to the same location, from accepting its touches.

This PR changes the implementation such that the custom `hitTest` is used only if the cell is not hidden.