### PR TITLE
Fix issue with swiping collection view cells on iOS 13

### DIFF
--- a/Source/SwipeCollectionViewCell.swift
+++ b/Source/SwipeCollectionViewCell.swift
@@ -80,9 +80,9 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     }
     
     func configure() {
-        contentView.clipsToBounds = false
+        clipsToBounds = false
         
-        swipeController = SwipeController(swipeable: self, actionsContainerView: contentView)
+        swipeController = SwipeController(swipeable: self, actionsContainerView: self)
         swipeController.delegate = self
     }
     
@@ -145,7 +145,7 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     }
     
     func contains(point: CGPoint) -> Bool {
-        return frame.contains(point)
+        return point.y > frame.minY && point.y < frame.maxY
     }
     
     // Override hitTest(_:with:) here so that we can make sure our `actionsView` gets the touch event
@@ -181,7 +181,7 @@ open class SwipeCollectionViewCell: UICollectionViewCell {
     }
     
     func reset() {
-        contentView.clipsToBounds = false
+        clipsToBounds = false
         swipeController.reset()
         collectionView?.setGestureEnabled(true)
     }


### PR DESCRIPTION
This PR contains fixes for swiping collection view cells on iOS 13. We found that by setting the cell itself as the action container view, following the table view cell's example, we were able to restore swiping behavior. Testing was done on a physical iOS 13 beta device and various iOS 12 simulators. No regressions were found using the demo app.