### PR TITLE
Improve Dark Mode support on iOS 13

### DIFF
--- a/Source/SwipeActionsView.swift
+++ b/Source/SwipeActionsView.swift
@@ -111,7 +111,11 @@ class SwipeActionsView: UIView {
         
         clipsToBounds = true
         translatesAutoresizingMaskIntoConstraints = false
-        backgroundColor = options.backgroundColor ?? #colorLiteral(red: 0.862745098, green: 0.862745098, blue: 0.862745098, alpha: 1)
+		if #available(iOS 13.0, *) {
+			backgroundColor = options.backgroundColor ?? .systemGroupedBackground
+		} else {
+			backgroundColor = options.backgroundColor ?? #colorLiteral(red: 0.862745098, green: 0.862745098, blue: 0.862745098, alpha: 1)
+		}
         
         buttons = addButtons(for: self.actions, withMaximum: maxSize, contentEdgeInsets: contentEdgeInsets)
     }
@@ -303,7 +307,11 @@ class SwipeActionButtonWrapperView: UIView {
             case .destructive:
                 actionBackgroundColor = #colorLiteral(red: 1, green: 0.2352941176, blue: 0.1882352941, alpha: 1)
             default:
-                actionBackgroundColor = #colorLiteral(red: 0.862745098, green: 0.862745098, blue: 0.862745098, alpha: 1)
+				if #available(iOS 13.0, *) {
+					actionBackgroundColor = .systemGroupedBackground
+				} else {
+					actionBackgroundColor = #colorLiteral(red: 0.862745098, green: 0.862745098, blue: 0.862745098, alpha: 1)
+				}
             }
         }
     }


### PR DESCRIPTION
When running on iOS 13 in Dark Mode, the background color of the SwipeActionsView was using light gray. Instead the background color should use the new .systemGroupedBackground color.

The change consists of using the new .systemGroupedBackground color for the background color on iOS 13, with a fallback to the old hardcoded color on older iOS versions.

Here is a screenshot before the PR:
<img width="420" alt="before" src="https://user-images.githubusercontent.com/738543/64133159-96e71c00-cdd4-11e9-8836-f59149b948fe.png">

Here is a screenshot after the PR:
<img width="416" alt="after" src="https://user-images.githubusercontent.com/738543/64133173-abc3af80-cdd4-11e9-8d07-5baa4bae7b98.png">

