### PR TITLE
Add  option ExpansionFulfillmentStyle.none

### DIFF
--- a/Source/SwipeAction.swift
+++ b/Source/SwipeAction.swift
@@ -120,6 +120,9 @@ public enum ExpansionFulfillmentStyle {
 
     /// Implies the item will be reset and the actions view hidden upon action fulfillment.
     case reset
+
+    /// Implies the item will be same as in the end of animation.
+    case none
 }
 
 // MARK: - Internal

--- a/Source/SwipeController.swift
+++ b/Source/SwipeController.swift
@@ -437,6 +437,8 @@ extension SwipeController: SwipeActionsViewDelegate {
                 }
             case .reset:
                 self.hideSwipe(animated: true)
+            case .none:
+                self.reset()
             }
         }
         


### PR DESCRIPTION
to allow fulfill action without changing state, for example when it is needed to delete item in performBatchUpdate via changing model only (do not delete item via swipeController)